### PR TITLE
Rename interfaces

### DIFF
--- a/examples/cartpole/models/model.py
+++ b/examples/cartpole/models/model.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 from typing import Sequence
 
 import torch.nn as nn
-import torch.nn.functional as F
 from gymnasium import spaces
 from torch import Tensor
 
 from parllel.torch.agents.categorical import DistParams, ModelOutputs
 from parllel.torch.models import MlpModel
-from parllel.torch.utils import infer_leading_dims, restore_leading_dims
 
 
 class CartPoleFfPgModel(nn.Module):
@@ -22,7 +20,8 @@ class CartPoleFfPgModel(nn.Module):
     ) -> None:
         super().__init__()
         assert isinstance(obs_space, spaces.Box)
-        obs_shape = obs_space.shape[0]
+        assert len(obs_space.shape) == 1
+        obs_size = obs_space.shape[0]
 
         assert isinstance(action_space, spaces.Discrete)
         n_actions = int(action_space.n)
@@ -30,25 +29,22 @@ class CartPoleFfPgModel(nn.Module):
         hidden_nonlinearity = getattr(nn, hidden_nonlinearity)
 
         self.pi = MlpModel(
-            input_size=obs_shape,
+            input_size=obs_size,
             hidden_sizes=hidden_sizes,
             output_size=n_actions,
             hidden_nonlinearity=hidden_nonlinearity,
         )
 
         self.value = MlpModel(
-            input_size=obs_shape,
+            input_size=obs_size,
             hidden_sizes=hidden_sizes,
             output_size=1,
             hidden_nonlinearity=hidden_nonlinearity,
         )
 
     def forward(self, observation: Tensor) -> ModelOutputs:
-        lead_dim, T, B, _ = infer_leading_dims(observation, 1)
+        assert len(observation.shape) == 2
 
-        probs = F.softmax(self.pi(observation.view(T * B, -1)), dim=-1)
-        value = self.value(observation.view(T * B, -1)).squeeze(-1)
-
-        probs, value = restore_leading_dims((probs, value), lead_dim, T, B)
-
+        probs = self.pi(observation).softmax(dim=-1)
+        value = self.value(observation).squeeze(-1)
         return ModelOutputs(dist_params=DistParams(probs=probs), value=value)

--- a/examples/cartpole/train_ppo.py
+++ b/examples/cartpole/train_ppo.py
@@ -1,14 +1,17 @@
+# fmt: off
 import multiprocessing as mp
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
+# isort: off
 import hydra
 import torch
 import wandb
 from gymnasium import spaces
 from omegaconf import DictConfig, OmegaConf
 
+# isort: on
 import parllel.logger as logger
 from parllel.cages import TrajInfo
 from parllel.logger import Verbosity
@@ -25,13 +28,14 @@ from parllel.torch.distributions import Categorical
 from parllel.transforms import Compose
 from parllel.types import BatchSpec
 
+# isort: split
 from envs.cartpole import build_cartpole
 from models.model import CartPoleFfPgModel
 
 
+# fmt: on
 @contextmanager
 def build(config: DictConfig) -> OnPolicyRunner:
-
     parallel = config["parallel"]
     batch_spec = BatchSpec(
         config["batch_T"],
@@ -135,7 +139,7 @@ def build(config: DictConfig) -> OnPolicyRunner:
         lr=config["algo"]["learning_rate"],
         **config.get("optimizer", {}),
     )
-    
+
     # create algorithm
     algorithm = PPO(
         agent=agent,
@@ -155,7 +159,7 @@ def build(config: DictConfig) -> OnPolicyRunner:
 
     try:
         yield runner
-    
+
     finally:
         sampler.close()
         agent.close()
@@ -166,11 +170,10 @@ def build(config: DictConfig) -> OnPolicyRunner:
 
 @hydra.main(version_base=None, config_path="conf", config_name="train_ppo")
 def main(config: DictConfig) -> None:
-
     mp.set_start_method("fork")
 
     run = wandb.init(
-        anonymous="must", # for this example, send to wandb dummy account
+        anonymous="must",  # for this example, send to wandb dummy account
         project="CartPole",
         tags=["discrete", "state-based", "ppo", "feedforward"],
         config=OmegaConf.to_container(config, resolve=True, throw_on_missing=True),
@@ -181,7 +184,9 @@ def main(config: DictConfig) -> None:
     logger.init(
         wandb_run=run,
         # this log_dir is used if wandb is disabled (using `wandb disabled`)
-        log_dir=Path(f"log_data/cartpole-ppo/{datetime.now().strftime('%Y-%m-%d_%H-%M')}"),
+        log_dir=Path(
+            f"log_data/cartpole-ppo/{datetime.now().strftime('%Y-%m-%d_%H-%M')}"
+        ),
         tensorboard=True,
         output_files={
             "txt": "log.txt",

--- a/examples/continuous_cartpole/train_ppo.py
+++ b/examples/continuous_cartpole/train_ppo.py
@@ -1,14 +1,17 @@
+# fmt: off
 import multiprocessing as mp
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
+# isort: off
 import hydra
 import torch
 import wandb
 from gymnasium import spaces
 from omegaconf import DictConfig, OmegaConf
 
+# isort: on
 import parllel.logger as logger
 from parllel.cages import TrajInfo
 from parllel.logger import Verbosity
@@ -25,13 +28,14 @@ from parllel.torch.distributions import Gaussian
 from parllel.transforms import Compose
 from parllel.types import BatchSpec
 
+# isort: split
 from envs.continuous_cartpole import build_cartpole
 from models.pg_model import GaussianCartPoleFfPgModel
 
 
+# fmt: on
 @contextmanager
 def build(config: DictConfig) -> OnPolicyRunner:
-
     parallel = config["parallel"]
     batch_spec = BatchSpec(
         config["batch_T"],
@@ -135,7 +139,7 @@ def build(config: DictConfig) -> OnPolicyRunner:
         lr=config["algo"]["learning_rate"],
         **config.get("optimizer", {}),
     )
-    
+
     # create algorithm
     algorithm = PPO(
         agent=agent,
@@ -155,7 +159,7 @@ def build(config: DictConfig) -> OnPolicyRunner:
 
     try:
         yield runner
-    
+
     finally:
         sampler.close()
         agent.close()
@@ -166,11 +170,10 @@ def build(config: DictConfig) -> OnPolicyRunner:
 
 @hydra.main(version_base=None, config_path="conf", config_name="train_ppo")
 def main(config: DictConfig) -> None:
-
     mp.set_start_method("fork")
 
     run = wandb.init(
-        anonymous="must", # for this example, send to wandb dummy account
+        anonymous="must",  # for this example, send to wandb dummy account
         project="Continuous CartPole",
         tags=["continuous", "state-based", "ppo", "feedforward"],
         config=OmegaConf.to_container(config, resolve=True, throw_on_missing=True),
@@ -181,7 +184,9 @@ def main(config: DictConfig) -> None:
     logger.init(
         wandb_run=run,
         # this log_dir is used if wandb is disabled (using `wandb disabled`)
-        log_dir=Path(f"log_data/continuous-cartpole-ppo/{datetime.now().strftime('%Y-%m-%d_%H-%M')}"),
+        log_dir=Path(
+            f"log_data/continuous-cartpole-ppo/{datetime.now().strftime('%Y-%m-%d_%H-%M')}"
+        ),
         tensorboard=True,
         output_files={
             "txt": "log.txt",

--- a/examples/pointcloud_rl/train_ppo.py
+++ b/examples/pointcloud_rl/train_ppo.py
@@ -65,7 +65,7 @@ def build(config: DictConfig) -> OnPolicyRunner:
         feature_shape=(obs_space.max_num_points,) + obs_space.shape,
         batch_shape=tuple(batch_spec),
         kind="jagged",
-        storage="managed" if parallel else "local",
+        storage="shared" if parallel else "local",
         padding=1,
     )
     sample_tree["observation"][0] = obs_space.sample()

--- a/examples/pointcloud_rl/train_ppo.py
+++ b/examples/pointcloud_rl/train_ppo.py
@@ -62,8 +62,9 @@ def build(config: DictConfig) -> OnPolicyRunner:
     sample_tree["observation"] = dict_map(
         Array.from_numpy,
         metadata.example_obs,
-        feature_shape=(obs_space.max_num_points,) + obs_space.shape,
         batch_shape=tuple(batch_spec),
+        max_mean_num_elem=obs_space.max_num_points,
+        feature_shape=obs_space.shape,
         kind="jagged",
         storage="shared" if parallel else "local",
         padding=1,

--- a/examples/pointcloud_rl/train_sac.py
+++ b/examples/pointcloud_rl/train_sac.py
@@ -1,3 +1,4 @@
+# fmt: off
 import itertools
 import multiprocessing as mp
 from contextlib import contextmanager
@@ -32,6 +33,7 @@ from models.pointnet_q_and_pi import PointNetPiModel, PointNetQModel
 from pointcloud import PointCloudSpace
 
 
+# fmt: on
 @contextmanager
 def build(config: DictConfig) -> OffPolicyRunner:
     parallel = config["parallel"]

--- a/examples/pointcloud_rl/train_sac.py
+++ b/examples/pointcloud_rl/train_sac.py
@@ -59,8 +59,9 @@ def build(config: DictConfig) -> OffPolicyRunner:
     sample_tree["observation"] = dict_map(
         Array.from_numpy,
         metadata.example_obs,
-        feature_shape=(obs_space.max_num_points,) + obs_space.shape,
         batch_shape=tuple(batch_spec),
+        max_mean_num_elem=obs_space.max_num_points,
+        feature_shape=obs_space.shape,
         kind="jagged",
         storage="managed" if parallel else "local",
         padding=1,
@@ -215,9 +216,9 @@ def main(config: DictConfig) -> None:
     logger.init(
         wandb_run=run,
         # this log_dir is used if wandb is disabled (using `wandb disabled`)
-        log_dir=Path(
-            f"log_data/pointcloud-sac/{datetime.now().strftime('%Y-%m-%d_%H-%M')}"
-        ),
+        # log_dir=Path(
+        #     f"log_data/pointcloud-sac/{datetime.now().strftime('%Y-%m-%d_%H-%M')}"
+        # ),
         tensorboard=True,
         output_files={
             "txt": "log.txt",

--- a/parllel/arrays/__init__.py
+++ b/parllel/arrays/__init__.py
@@ -4,11 +4,11 @@ import parllel.tree
 from .array import Array
 from .indices import Index, Location
 
+# isort: split
 # these modules are only imported to register the types they define
 import parllel.arrays.jagged
 import parllel.arrays.managedmemory
 import parllel.arrays.sharedmemory
-
 
 __all__ = [
     "Array",

--- a/parllel/arrays/array.py
+++ b/parllel/arrays/array.py
@@ -51,7 +51,7 @@ class Array:
     ) -> Array:
         # fill in empty arguments with values from class used to instantiate
         # can instantiate a subclass directly by just not passing kind/storage
-        # e.g. SharedMemoryArray(shape=(4,4), dtype=np.float32)
+        # e.g. JaggedArray(shape=(4,4), dtype=np.float32)
         kind = kind if kind is not None else cls.kind
         storage = storage if storage is not None else cls.storage
 

--- a/parllel/arrays/array.py
+++ b/parllel/arrays/array.py
@@ -121,14 +121,15 @@ class Array:
 
     def new_array(
         self,
-        feature_shape: tuple[int, ...] | None = None,
-        dtype: np.dtype | None = None,
         batch_shape: tuple[int, ...] | None = None,
+        dtype: np.dtype | None = None,
+        feature_shape: tuple[int, ...] | None = None,
         kind: str | None = None,
         storage: str | None = None,
         padding: int | None = None,
         full_size: int | None = None,
         inherit_full_size: bool = False,
+        **kwargs,
     ) -> Array:
         """Creates an Array with the same shape and type as a given Array
         (similar to torch's new_zeros function). By default, the full size of
@@ -170,20 +171,22 @@ class Array:
             storage=storage,
             padding=padding,
             full_size=full_size,
+            **kwargs,
         )
 
     @classmethod
     def from_numpy(
         cls,
         example: Any,
-        feature_shape: tuple[int, ...] | None = None,
+        batch_shape: tuple[int, ...],
         dtype: np.dtype | None = None,
+        feature_shape: tuple[int, ...] | None = None,
         force_32bit: Literal[True, "float", "int", False] = True,
-        batch_shape: tuple[int, ...] = (),
         kind: str | None = None,
         storage: str | None = None,
         padding: int = 0,
         full_size: int | None = None,
+        **kwargs,
     ) -> Array:
         np_example: np.ndarray = np.asanyarray(example)  # promote scalars to 0d arrays
         feature_shape = feature_shape if feature_shape is not None else np_example.shape
@@ -201,6 +204,7 @@ class Array:
             storage=storage,
             padding=padding,
             full_size=full_size,
+            **kwargs,
         )
 
     def _allocate(self, shape: tuple[int, ...], dtype: np.dtype, name: str) -> None:

--- a/parllel/arrays/jagged.py
+++ b/parllel/arrays/jagged.py
@@ -11,8 +11,8 @@ from parllel import ArrayDict
 from parllel.arrays.array import Array
 from parllel.arrays.indices import (Location, StandardIndex, add_locations,
                                     index_slice, init_location)
-from parllel.arrays.managedmemory import ManagedMemoryArray
-from parllel.arrays.sharedmemory import SharedMemoryArray
+from parllel.arrays.managedmemory import SharedMemoryArray
+from parllel.arrays.sharedmemory import InheritedMemoryArray
 
 # fmt: on
 
@@ -306,14 +306,14 @@ class JaggedArray(Array, kind="jagged"):
         )
 
 
-class SharedMemoryJaggedArray(
-    SharedMemoryArray, JaggedArray, kind="jagged", storage="shared"
+class InheritedMemoryJaggedArray(
+    InheritedMemoryArray, JaggedArray, kind="jagged", storage="inherited"
 ):
     pass
 
 
-class ManagedMemoryJaggedArray(
-    ManagedMemoryArray, JaggedArray, kind="jagged", storage="managed"
+class SharedMemoryJaggedArray(
+    SharedMemoryArray, JaggedArray, kind="jagged", storage="shared"
 ):
     pass
 

--- a/parllel/arrays/managedmemory.py
+++ b/parllel/arrays/managedmemory.py
@@ -10,12 +10,12 @@ import parllel.logger as logger
 from .array import Array
 
 
-class ManagedMemoryArray(Array, storage="managed"):
+class SharedMemoryArray(Array, storage="shared"):
     """An array in OS shared memory that can be shared between processes at any
     time.
     """
 
-    storage = "managed"
+    storage = "shared"
 
     def _allocate(self, shape: tuple[int, ...], dtype: np.dtype, name: str) -> None:
         # allocate array in OS shared memory

--- a/parllel/arrays/sharedmemory.py
+++ b/parllel/arrays/sharedmemory.py
@@ -7,13 +7,13 @@ import numpy as np
 from .array import Array
 
 
-class SharedMemoryArray(Array, storage="shared"):
+class InheritedMemoryArray(Array, storage="inherited"):
     """An array in OS shared memory that can be shared between processes on
     process startup only (i.e. process inheritance). Starting processes with
     the `spawn` method is also supported.
     """
 
-    storage = "shared"
+    storage = "inherited"
 
     def _allocate(self, shape: tuple[int, ...], dtype: np.dtype, name: str) -> None:
         # allocate array in OS shared memory

--- a/parllel/arrays/tests/array_test.py
+++ b/parllel/arrays/tests/array_test.py
@@ -42,7 +42,7 @@ def full_size(request):
 @pytest.fixture
 def blank_array(ArrayClass, shape, dtype, storage, padding, full_size):
     array = ArrayClass(
-        feature_shape=shape,
+        batch_shape=shape,
         dtype=dtype,
         storage=storage,
         padding=padding,
@@ -68,14 +68,14 @@ class TestArrayCreation:
 
     def test_empty_shape(self, ArrayClass, dtype):
         with pytest.raises(ValueError):
-            _ = ArrayClass(feature_shape=(), dtype=dtype)
+            _ = ArrayClass(batch_shape=(), dtype=dtype)
 
     def test_wrong_dtype(self, ArrayClass, shape):
         with pytest.raises(ValueError):
-            _ = ArrayClass(feature_shape=shape, dtype=list)
+            _ = ArrayClass(batch_shape=shape, dtype=list)
 
     def test_calling_array(self, ArrayClass, shape, dtype, storage, padding):
-        array = ArrayClass(feature_shape=shape, dtype=dtype, storage=storage, padding=padding)
+        array = ArrayClass(batch_shape=shape, dtype=dtype, storage=storage, padding=padding)
         assert array.shape == shape
         assert array.dtype == dtype
         assert array.storage == storage
@@ -87,16 +87,16 @@ class TestArrayCreation:
         elif storage == "managed":
             ArrayClass = ManagedMemoryArray
 
-        array = ArrayClass(feature_shape=shape, dtype=dtype, padding=padding)
+        array = ArrayClass(batch_shape=shape, dtype=dtype, padding=padding)
         assert array.shape == shape
         assert array.dtype == dtype
         assert array.storage == storage
         assert array.padding == padding
 
     def test_new_array(self):
-        template = Array(feature_shape=(10, 4), dtype=np.float32)
+        template = Array(batch_shape=(10, 4), dtype=np.float32)
         
-        array = template.new_array(feature_shape=(20, 4))
+        array = template.new_array(batch_shape=(20, 4))
         assert array.shape == (20, 4)
         assert array.dtype == np.float32
         assert array.full.shape == (20, 4)
@@ -117,14 +117,14 @@ class TestArrayCreation:
         assert array.full.shape == (20, 4)
 
     def test_new_array_windowed(self):
-        template = Array(feature_shape=(10, 4), dtype=np.float32, full_size=20)
+        template = Array(batch_shape=(10, 4), dtype=np.float32, full_size=20)
 
-        array = template.new_array(feature_shape=(5, 4))
+        array = template.new_array(batch_shape=(5, 4))
         assert array.shape == (5, 4)
         assert array.dtype == np.float32
         assert array.full.shape == (5, 4)
 
-        array = template.new_array(feature_shape=(5, 4), inherit_full_size=True)
+        array = template.new_array(batch_shape=(5, 4), inherit_full_size=True)
         assert array.shape == (5, 4)
         assert array.full.shape == (20, 4)
 

--- a/parllel/arrays/tests/array_test.py
+++ b/parllel/arrays/tests/array_test.py
@@ -5,8 +5,8 @@ import numpy as np
 import pytest
 
 from parllel.arrays import Array
-from parllel.arrays.managedmemory import ManagedMemoryArray
-from parllel.arrays.sharedmemory import SharedMemoryArray
+from parllel.arrays.managedmemory import SharedMemoryArray
+from parllel.arrays.sharedmemory import InheritedMemoryArray
 
 # fmt: off
 @pytest.fixture(params=[
@@ -25,8 +25,8 @@ def dtype(request):
 
 @pytest.fixture(params=[
     "local",
+    "inherited",
     "shared",
-    "managed",
 ], scope="module")
 def storage(request):
     return request.param
@@ -82,10 +82,10 @@ class TestArrayCreation:
         assert array.padding == padding
 
     def test_calling_subclass(self, ArrayClass, shape, dtype, storage, padding):
-        if storage == "shared":
+        if storage == "inherited":
+            ArrayClass = InheritedMemoryArray
+        elif storage == "shared":
             ArrayClass = SharedMemoryArray
-        elif storage == "managed":
-            ArrayClass = ManagedMemoryArray
 
         array = ArrayClass(batch_shape=shape, dtype=dtype, padding=padding)
         assert array.shape == shape
@@ -105,8 +105,8 @@ class TestArrayCreation:
         assert array.shape == (10, 4)
         assert array.dtype == np.int32
 
-        array = template.new_array(storage="shared")
-        assert array.storage == "shared"
+        array = template.new_array(storage="inherited")
+        assert array.storage == "inherited"
         array.close()
 
         array = template.new_array(padding=1)
@@ -132,8 +132,8 @@ class TestArrayCreation:
         assert array.shape == (10, 4)
         assert array.dtype == np.int32
 
-        array = template.new_array(storage="shared")
-        assert array.storage == "shared"
+        array = template.new_array(storage="inherited")
+        assert array.storage == "inherited"
         array.close()
 
         array = template.new_array(padding=1)

--- a/parllel/arrays/tests/full_size_test.py
+++ b/parllel/arrays/tests/full_size_test.py
@@ -13,7 +13,7 @@ def full_size(request):
 class TestFullSize:
     def test_nonmultiple_fullsize(self, ArrayClass, shape, dtype, storage):
         with pytest.raises(ValueError):
-            _ = ArrayClass(feature_shape=shape, dtype=dtype, storage=storage, full_size=15)
+            _ = ArrayClass(batch_shape=shape, dtype=dtype, storage=storage, full_size=15)
 
     def test_rotate(self, array, np_array, padding):
         array.rotate()

--- a/parllel/arrays/tests/jagged_test.py
+++ b/parllel/arrays/tests/jagged_test.py
@@ -50,9 +50,10 @@ def full_size(request):
 @pytest.fixture
 def blank_array(ArrayClass, max_points, feature_shape, dtype, batch_shape, storage, padding, full_size):
     array = ArrayClass(
-        feature_shape=(max_points,) + feature_shape,
-        dtype=dtype,
         batch_shape=batch_shape,
+        dtype=dtype,
+        max_mean_num_elem=max_points,
+        feature_shape=feature_shape,
         storage=storage,
         padding=padding,
         full_size=full_size,
@@ -136,11 +137,12 @@ class TestJaggedArray:
         assert np.array_equal(np_batch, batch)
 
     def test_rotate(self, blank_array: JaggedArray, graph_generator):
-        batch_shape, shape = blank_array.shape[:2], blank_array.shape[2:]
+        batch_shape, feature_shape = blank_array.shape[:2], blank_array.shape[3:]
         array = JaggedArray(
-            feature_shape=shape,
-            dtype=blank_array.dtype,
             batch_shape=batch_shape,
+            dtype=blank_array.dtype,
+            max_mean_num_elem=blank_array.max_mean_num_elem,
+            feature_shape=feature_shape,
             padding=1,
         )
 

--- a/parllel/arrays/tests/managedmemory_test.py
+++ b/parllel/arrays/tests/managedmemory_test.py
@@ -27,7 +27,7 @@ def dtype(request):
     return request.param
 
 @pytest.fixture(params=[
-    "managed",
+    "shared",
     ], scope="module")
 def storage(request):
     return request.param
@@ -51,7 +51,7 @@ def get_piped_array_shape(pipe):
     pipe.send(subarray.shape)
 
 
-class TestManagedMemoryArray:
+class TestSharedMemoryArray:
     def test_setitem_single(self, array, np_array, mp_ctx):
         location = (0, 1, 2)
         value = -7

--- a/parllel/arrays/tests/padding_test.py
+++ b/parllel/arrays/tests/padding_test.py
@@ -33,7 +33,7 @@ def array(blank_array, np_array, padding, previous_region, next_region):
 class TestPaddedArray:
     def test_negative_padding(self, ArrayClass, shape, dtype, storage):
         with pytest.raises(ValueError):
-            _ = ArrayClass(feature_shape=shape, dtype=dtype, storage=storage, padding=-1)
+            _ = ArrayClass(batch_shape=shape, dtype=dtype, storage=storage, padding=-1)
 
     def test_init(self, blank_array, shape, dtype):
         assert blank_array.shape == shape

--- a/parllel/arrays/tests/sharedmemory_test.py
+++ b/parllel/arrays/tests/sharedmemory_test.py
@@ -28,8 +28,8 @@ def dtype(request):
     return request.param
 
 @pytest.fixture(params=[
+    "inherited",
     "shared",
-    "managed",
 ], scope="module")
 def storage(request):
     return request.param
@@ -47,7 +47,7 @@ def get_array_shape(pipe, array):
     pipe.send(array.shape)
 
 
-class TestSharedMemoryArray:
+class TestInheritedMemoryArray:
     def test_setitem_single(self, array, np_array, mp_ctx):
         location = (0, 1, 2)
         value = -7

--- a/parllel/patterns.py
+++ b/parllel/patterns.py
@@ -46,7 +46,7 @@ def build_cages_and_sample_tree(
 ) -> tuple[list[Cage], ArrayDict[Array], Metadata]:
     if parallel:
         CageCls = ProcessCage
-        storage = "managed"
+        storage = "shared"
     else:
         CageCls = SerialCage
         storage = "local"

--- a/parllel/patterns.py
+++ b/parllel/patterns.py
@@ -95,8 +95,8 @@ def build_cages_and_sample_tree(
             Array.from_numpy,
             reward,
             batch_shape=tuple(batch_spec),
-            feature_shape=(),
             dtype=np.float32,
+            feature_shape=(),
             storage=storage,
             full_size=full_size,
         )
@@ -105,8 +105,8 @@ def build_cages_and_sample_tree(
         sample_tree["terminated"] = Array.from_numpy(
             terminated,
             batch_shape=tuple(batch_spec),
-            feature_shape=(),
             dtype=bool,
+            feature_shape=(),
             storage=storage,
             full_size=full_size,  # used for SAC replay buffer
         )
@@ -115,8 +115,8 @@ def build_cages_and_sample_tree(
         sample_tree["truncated"] = Array.from_numpy(
             truncated,
             batch_shape=tuple(batch_spec),
-            feature_shape=(),
             dtype=bool,
+            feature_shape=(),
             storage=storage,
         )
 
@@ -127,8 +127,8 @@ def build_cages_and_sample_tree(
         sample_tree["done"] = Array.from_numpy(
             terminated,
             batch_shape=tuple(batch_spec),
-            feature_shape=(),
             dtype=bool,
+            feature_shape=(),
             storage=storage,
             padding=1,
         )


### PR DESCRIPTION
Make batch_shape required argument to Array instead of feature_shape.
Rename managed memory to shared memory and shared memory to inherited memory.
Allow indexing only with Ellipsis after advanced indexing.
Give JaggedArray explicit max_mean_num_elems argument.
Override from_numpy and new_array in Jagged to preserve max_mean_num_elems.
Clean up example models.