### PR TITLE
Use terminated as bootstrapping signal in SAC.

### DIFF
--- a/benchmarks/sb3/build_parllel_sac.py
+++ b/benchmarks/sb3/build_parllel_sac.py
@@ -132,8 +132,19 @@ def build(config: DictConfig) -> Iterator[RLRunner]:
 
     if config["algo"]["learning_rate_type"] == "linear":
         lr_schedulers = [
-            torch.optim.lr_scheduler.LinearLR(pi_optimizer),
-            torch.optim.lr_scheduler.LinearLR(q_optimizer),
+            torch.optim.lr_scheduler.LinearLR(
+                pi_optimizer,
+                start_factor=1.0,
+                end_factor=0.0,
+                # TODO: adjust total iters for delayed learning start
+                total_iters=max(1, int(config["runner"]["n_steps"] // batch_spec.size)),
+            ),
+            torch.optim.lr_scheduler.LinearLR(
+                q_optimizer,
+                start_factor=1.0,
+                end_factor=0.0,
+                total_iters=max(1, int(config["runner"]["n_steps"] // batch_spec.size)),
+            ),
         ]
     else:
         lr_schedulers = None

--- a/benchmarks/sb3/build_parllel_sac.py
+++ b/benchmarks/sb3/build_parllel_sac.py
@@ -116,28 +116,36 @@ def build(config: DictConfig) -> Iterator[RLRunner]:
         batch_transform=lambda tree: tree.to(device=device),
     )
 
-    optimizers = {
-        "pi": torch.optim.Adam(
-            agent.model["pi"].parameters(),
-            lr=config["algo"]["learning_rate"],
-            **config.get("optimizer", {}),
+    q_optimizer = torch.optim.Adam(
+        itertools.chain(
+            agent.model["q1"].parameters(),
+            agent.model["q2"].parameters(),
         ),
-        "q": torch.optim.Adam(
-            itertools.chain(
-                agent.model["q1"].parameters(),
-                agent.model["q2"].parameters(),
-            ),
-            lr=config["algo"]["learning_rate"],
-            **config.get("optimizer", {}),
-        ),
-    }
+        lr=config["algo"]["learning_rate"],
+        **config.get("optimizer", {}),
+    )
+    pi_optimizer = torch.optim.Adam(
+        agent.model["pi"].parameters(),
+        lr=config["algo"]["learning_rate"],
+        **config.get("optimizer", {}),
+    )
+
+    if config["algo"]["learning_rate_type"] == "linear":
+        lr_schedulers = [
+            torch.optim.lr_scheduler.LinearLR(pi_optimizer),
+            torch.optim.lr_scheduler.LinearLR(q_optimizer),
+        ]
+    else:
+        lr_schedulers = None
 
     # create algorithm
     algorithm = SAC(
         batch_spec=batch_spec,
         agent=agent,
         replay_buffer=replay_buffer,
-        optimizers=optimizers,
+        q_optimizer=q_optimizer,
+        pi_optimizer=pi_optimizer,
+        learning_rate_schedulers=lr_schedulers,
         **config["algo"],
     )
 

--- a/benchmarks/sb3/build_sb3_sac.py
+++ b/benchmarks/sb3/build_sb3_sac.py
@@ -58,6 +58,7 @@ def build(config: DictConfig) -> Iterator[tuple[BaseAlgorithm, BaseCallback]]:
     eval_env = DummyVecEnv([make_env for _ in range(config["n_envs"])])
     eval_callback = EvalCallback(
         eval_env,
+        n_eval_episodes=config["n_eval_episodes"],
         eval_freq=config["eval_interval_steps"],
         deterministic=config["deterministic_eval_mode"],
     )

--- a/benchmarks/sb3/build_sb3_sac.py
+++ b/benchmarks/sb3/build_sb3_sac.py
@@ -36,6 +36,17 @@ def build(config: DictConfig) -> Iterator[tuple[BaseAlgorithm, BaseCallback]]:
         resolve=True,
         throw_on_missing=True,
     )
+
+    if isinstance(lr := algo_config["learning_rate"], str):
+        schedule, initial_value = lr.split("_")
+        assert schedule == "lin"
+        initial_value = float(initial_value)
+
+        def linear_schedule(progress_remaining: float) -> float:
+            return progress_remaining * initial_value
+
+        algo_config["learning_rate"] = linear_schedule
+
     model = SAC(
         "MlpPolicy",
         env,

--- a/benchmarks/sb3/conf/logdirs.yaml
+++ b/benchmarks/sb3/conf/logdirs.yaml
@@ -1,0 +1,5 @@
+hydra:
+  run:
+    dir: outputs/${hydra.job.name}/${framework}/${now:%Y-%m-%d_%H-%M-%S}
+  sweep:
+    dir: multirun/${hydra.job.name}/${framework}/${now:%Y-%m-%d_%H-%M-%S}

--- a/benchmarks/sb3/conf/sac_cheetah_parllel.yaml
+++ b/benchmarks/sb3/conf/sac_cheetah_parllel.yaml
@@ -1,45 +1,10 @@
 defaults:
+  - sac_parllel
+  - logdirs
   - _self_
 
 hydra:
   job:
     name: cheetah-sac
-  run:
-    dir: outputs/${hydra.job.name}/${framework}/${now:%Y-%m-%d_%H-%M-%S}
-  sweep:
-    dir: multirun/${hydra.job.name}/${framework}/${now:%Y-%m-%d_%H-%M-%S}
 
-framework: parllel
 env_name: HalfCheetah-v4
-parallel: False  # for fast environments, no speedup with parallel processes
-batch_T: 8  # corresponds to "raw" train_freq in SB3
-batch_B: 8
-device: null
-pi_model:
-  hidden_sizes: [400, 300]  # from rl-baselines3-zoo
-  hidden_nonlinearity: ReLU  # from Haarnoja et al.
-q_model:
-  hidden_sizes: [400, 300]  # from rl-baselines3-zoo
-  hidden_nonlinearity: ReLU  # from Haarnoja et al.
-distribution:
-  deterministic_eval_mode: False  # from rl-baselines3-zoo
-algo:
-  learning_rate: 7.3e-4  # from rl-baselines3-zoo
-  replay_size: 300000  # from rl-baselines3-zoo
-  batch_size: 256  # from Haarnoja et al.
-  ent_coeff: 0.005  # cannot use auto, as parllel doesn't support this
-  discount: 0.98  # from rl-baselines3-zoo
-  target_update_tau: 0.02  # from rl-baselines3-zoo
-  replay_ratio: 32  # rl-baselines3-zoo does 8 gradient updates with batch size 256 per 8 env steps, equivalent to replay_ratio 256. reduced here to make training faster
-  learning_starts: 10000  # from rl-baselines3-zoo
-  random_explore_steps: 10000  # from rl-baselines3-zoo
-  target_update_interval: 1  # default for SB3, also matches Haarnoja et al.
-  clip_grad_norm: null
-eval_sampler:
-  max_traj_length: 2000
-  max_trajectories: 40
-  n_eval_envs: 16
-runner:
-  n_steps: 1.e+6
-  log_interval_steps: 50000
-  eval_interval_steps: 50000

--- a/benchmarks/sb3/conf/sac_cheetah_sb3.yaml
+++ b/benchmarks/sb3/conf/sac_cheetah_sb3.yaml
@@ -1,32 +1,13 @@
 defaults:
+  - sac_sb3
+  - logdirs
   - _self_
 
 hydra:
   job:
     name: cheetah-sac
-  run:
-    dir: outputs/${hydra.job.name}/${framework}/${now:%Y-%m-%d_%H-%M-%S}
-  sweep:
-    dir: multirun/${hydra.job.name}/${framework}/${now:%Y-%m-%d_%H-%M-%S}
 
-framework: sb3
+# hyperparameters for HalfCheetah are here:
+# https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml#L74
 env_name: HalfCheetah-v4
-n_envs: 8  # rl-baselines3-zoo uses only 1 parallel environment
-deterministic_eval_mode: False  # rl-baselines3-zoo uses non-deterministic eval only for Atari and "minigrid" environments
-n_steps: 1.e+6
 log_interval_episodes: 50  # each episode is 1000 steps
-eval_interval_steps: 50000
-algo:  # taken from https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml#L74
-  learning_rate: 7.3e-4
-  buffer_size: 300000
-  batch_size: 256
-  ent_coef: 0.005  # cannot use auto, as parllel doesn't support this
-  gamma: 0.98
-  tau: 0.02
-  train_freq: 64  # corresponds to sampler batch size in parllel
-  gradient_steps: 8
-  learning_starts: 10000
-  use_sde: False  # need to disable, as parllel doesn't support this
-  policy_kwargs:
-    log_std_init: -3
-    net_arch: [400, 300]

--- a/benchmarks/sb3/conf/sac_hopper_parllel.yaml
+++ b/benchmarks/sb3/conf/sac_hopper_parllel.yaml
@@ -8,3 +8,5 @@ hydra:
     name: hopper-sac
 
 env_name: Hopper-v4
+algo:
+  learning_rate_type: linear

--- a/benchmarks/sb3/conf/sac_hopper_sb3.yaml
+++ b/benchmarks/sb3/conf/sac_hopper_sb3.yaml
@@ -11,3 +11,5 @@ hydra:
 # https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml#L100C20-L100C20
 log_interval_episodes: 100  # each episode is up to 1000 steps
 env_name: Hopper-v4
+algo:
+  learning_rate: lin_7.3e-4

--- a/benchmarks/sb3/conf/sac_hopper_sb3.yaml
+++ b/benchmarks/sb3/conf/sac_hopper_sb3.yaml
@@ -1,32 +1,13 @@
 defaults:
+  - sac_sb3
+  - logdirs
   - _self_
 
 hydra:
   job:
     name: hopper-sac
-  run:
-    dir: outputs/${hydra.job.name}/${framework}/${now:%Y-%m-%d_%H-%M-%S}
-  sweep:
-    dir: multirun/${hydra.job.name}/${framework}/${now:%Y-%m-%d_%H-%M-%S}
 
-framework: sb3
-env_name: Hopper-v4
-n_envs: 8  # rl-baselines3-zoo uses only 1 parallel environment
-deterministic_eval_mode: False  # rl-baselines3-zoo uses non-deterministic eval only for Atari and "minigrid" environments
-n_steps: 1.e+6
+# hyperparameters for Hopper are here:
+# https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml#L100C20-L100C20
 log_interval_episodes: 100  # each episode is up to 1000 steps
-eval_interval_steps: 50000
-algo:  # taken from https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml#L100C20-L100C20
-  learning_rate: 7.3e-4
-  buffer_size: 300000
-  batch_size: 256
-  ent_coef: 0.005  # cannot use auto, as parllel doesn't support this
-  gamma: 0.98
-  tau: 0.02
-  train_freq: 64  # corresponds to sampler batch size in parllel
-  gradient_steps: 8
-  learning_starts: 10000
-  use_sde: False  # need to disable, as parllel doesn't support this
-  policy_kwargs:
-    log_std_init: -3
-    net_arch: [400, 300]
+env_name: Hopper-v4

--- a/benchmarks/sb3/conf/sac_parllel.yaml
+++ b/benchmarks/sb3/conf/sac_parllel.yaml
@@ -13,6 +13,7 @@ distribution:
   deterministic_eval_mode: False  # from rl-baselines3-zoo
 algo:
   learning_rate: 7.3e-4  # from rl-baselines3-zoo
+  learning_rate_type: constant
   replay_size: 300000  # from rl-baselines3-zoo
   batch_size: 256  # from Haarnoja et al.
   ent_coeff: 0.005  # cannot use auto, as parllel doesn't support this

--- a/benchmarks/sb3/conf/sac_parllel.yaml
+++ b/benchmarks/sb3/conf/sac_parllel.yaml
@@ -1,0 +1,33 @@
+framework: parllel
+parallel: False  # for fast environments, no speedup with parallel processes
+batch_T: 8  # corresponds to "raw" train_freq in SB3
+batch_B: 8
+device: null
+pi_model:
+  hidden_sizes: [400, 300]  # from rl-baselines3-zoo
+  hidden_nonlinearity: ReLU  # from Haarnoja et al.
+q_model:
+  hidden_sizes: [400, 300]  # from rl-baselines3-zoo
+  hidden_nonlinearity: ReLU  # from Haarnoja et al.
+distribution:
+  deterministic_eval_mode: False  # from rl-baselines3-zoo
+algo:
+  learning_rate: 7.3e-4  # from rl-baselines3-zoo
+  replay_size: 300000  # from rl-baselines3-zoo
+  batch_size: 256  # from Haarnoja et al.
+  ent_coeff: 0.005  # cannot use auto, as parllel doesn't support this
+  discount: 0.98  # from rl-baselines3-zoo
+  target_update_tau: 0.02  # from rl-baselines3-zoo
+  replay_ratio: 32  # rl-baselines3-zoo does 8 gradient updates with batch size 256 per 8 env steps, equivalent to replay_ratio 256. reduced here to make training faster
+  learning_starts: 10000  # from rl-baselines3-zoo
+  random_explore_steps: 10000  # from rl-baselines3-zoo
+  target_update_interval: 1  # default for SB3, also matches Haarnoja et al.
+  clip_grad_norm: null
+eval_sampler:
+  max_traj_length: 2000
+  max_trajectories: 40
+  n_eval_envs: 16
+runner:
+  n_steps: 1.e+6
+  log_interval_steps: 50000
+  eval_interval_steps: 50000

--- a/benchmarks/sb3/conf/sac_sb3.yaml
+++ b/benchmarks/sb3/conf/sac_sb3.yaml
@@ -2,7 +2,8 @@ framework: sb3
 n_envs: 8  # rl-baselines3-zoo uses only 1 parallel environment
 deterministic_eval_mode: False  # rl-baselines3-zoo uses non-deterministic eval only for Atari and "minigrid" environments
 n_steps: 1.e+6
-eval_interval_steps: 50000
+eval_interval_steps: 50000  # from SB3: https://stable-baselines3.readthedocs.io/en/master/modules/sac.html#how-to-replicate-the-results
+n_eval_episodes: 10  # from SB3: https://stable-baselines3.readthedocs.io/en/master/modules/sac.html#how-to-replicate-the-results
 algo:  # taken from https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml
   learning_rate: 7.3e-4
   buffer_size: 300000
@@ -15,5 +16,5 @@ algo:  # taken from https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hype
   learning_starts: 10000
   use_sde: False  # need to disable, as parllel doesn't support this
   policy_kwargs:
-    log_std_init: -3
+    # log_std_init: -3  # has no effect when use_sde=False
     net_arch: [400, 300]

--- a/benchmarks/sb3/conf/sac_sb3.yaml
+++ b/benchmarks/sb3/conf/sac_sb3.yaml
@@ -1,0 +1,19 @@
+framework: sb3
+n_envs: 8  # rl-baselines3-zoo uses only 1 parallel environment
+deterministic_eval_mode: False  # rl-baselines3-zoo uses non-deterministic eval only for Atari and "minigrid" environments
+n_steps: 1.e+6
+eval_interval_steps: 50000
+algo:  # taken from https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml
+  learning_rate: 7.3e-4
+  buffer_size: 300000
+  batch_size: 256
+  ent_coef: 0.005  # cannot use auto, as parllel doesn't support this
+  gamma: 0.98
+  tau: 0.02
+  train_freq: 64  # corresponds to sampler batch size in parllel
+  gradient_steps: 8
+  learning_starts: 10000
+  use_sde: False  # need to disable, as parllel doesn't support this
+  policy_kwargs:
+    log_std_init: -3
+    net_arch: [400, 300]

--- a/benchmarks/sb3/conf/sac_walker_parllel.yaml
+++ b/benchmarks/sb3/conf/sac_walker_parllel.yaml
@@ -8,3 +8,5 @@ hydra:
     name: walker2d-sac
 
 env_name: Walker2d-v4
+algo:
+  learning_rate_type: linear

--- a/benchmarks/sb3/conf/sac_walker_parllel.yaml
+++ b/benchmarks/sb3/conf/sac_walker_parllel.yaml
@@ -5,6 +5,6 @@ defaults:
 
 hydra:
   job:
-    name: hopper-sac
+    name: walker2d-sac
 
-env_name: Hopper-v4
+env_name: Walker2d-v4

--- a/benchmarks/sb3/conf/sac_walker_sb3.yaml
+++ b/benchmarks/sb3/conf/sac_walker_sb3.yaml
@@ -1,0 +1,13 @@
+defaults:
+  - sac_sb3
+  - logdirs
+  - _self_
+
+hydra:
+  job:
+    name: walker2d-sac
+
+# hyperparameters for Walker2d are here:
+# https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml#L104
+log_interval_episodes: 100  # each episode is up to 1000 steps
+env_name: Walker2d-v4

--- a/benchmarks/sb3/conf/sac_walker_sb3.yaml
+++ b/benchmarks/sb3/conf/sac_walker_sb3.yaml
@@ -11,3 +11,5 @@ hydra:
 # https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml#L104
 log_interval_episodes: 100  # each episode is up to 1000 steps
 env_name: Walker2d-v4
+algo:
+  learning_rate: lin_7.3e-4

--- a/benchmarks/sb3/train_all.sh
+++ b/benchmarks/sb3/train_all.sh
@@ -5,5 +5,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 python $SCRIPT_DIR/train_sac_cheetah_parllel.py -m +iteration="range(5)"
 python $SCRIPT_DIR/train_sac_hopper_parllel.py -m +iteration="range(5)"
+python $SCRIPT_DIR/train_sac_walker_parllel.py -m +iteration="range(5)"
 python $SCRIPT_DIR/train_sac_cheetah_sb3.py -m +iteration="range(5)"
 python $SCRIPT_DIR/train_sac_hopper_sb3.py -m +iteration="range(5)"
+python $SCRIPT_DIR/train_sac_walker_sb3.py -m +iteration="range(5)"

--- a/benchmarks/sb3/train_sac_cheetah_parllel.py
+++ b/benchmarks/sb3/train_sac_cheetah_parllel.py
@@ -4,6 +4,7 @@ import multiprocessing as mp
 # isort: off
 import hydra
 import wandb
+from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, OmegaConf
 
 # isort: on
@@ -26,6 +27,7 @@ def main(config: DictConfig) -> None:
 
     logger.init(
         wandb_run=run,
+        log_dir=HydraConfig.get().runtime.output_dir,
         tensorboard=True,
         config=OmegaConf.to_container(config, resolve=True, throw_on_missing=True),
     )

--- a/benchmarks/sb3/train_sac_cheetah_parllel.py
+++ b/benchmarks/sb3/train_sac_cheetah_parllel.py
@@ -29,7 +29,6 @@ def main(config: DictConfig) -> None:
         wandb_run=run,
         log_dir=HydraConfig.get().runtime.output_dir,
         tensorboard=True,
-        config=OmegaConf.to_container(config, resolve=True, throw_on_missing=True),
     )
 
     with build(config) as runner:

--- a/benchmarks/sb3/train_sac_hopper_parllel.py
+++ b/benchmarks/sb3/train_sac_hopper_parllel.py
@@ -4,6 +4,7 @@ import multiprocessing as mp
 # isort: off
 import hydra
 import wandb
+from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, OmegaConf
 
 # isort: on
@@ -26,6 +27,7 @@ def main(config: DictConfig) -> None:
 
     logger.init(
         wandb_run=run,
+        log_dir=HydraConfig.get().runtime.output_dir,
         tensorboard=True,
         config=OmegaConf.to_container(config, resolve=True, throw_on_missing=True),
     )

--- a/benchmarks/sb3/train_sac_hopper_parllel.py
+++ b/benchmarks/sb3/train_sac_hopper_parllel.py
@@ -29,7 +29,6 @@ def main(config: DictConfig) -> None:
         wandb_run=run,
         log_dir=HydraConfig.get().runtime.output_dir,
         tensorboard=True,
-        config=OmegaConf.to_container(config, resolve=True, throw_on_missing=True),
     )
 
     with build(config) as runner:

--- a/benchmarks/sb3/train_sac_walker_parllel.py
+++ b/benchmarks/sb3/train_sac_walker_parllel.py
@@ -1,0 +1,43 @@
+# fmt: off
+import multiprocessing as mp
+
+# isort: off
+import hydra
+import wandb
+from hydra.core.hydra_config import HydraConfig
+from omegaconf import DictConfig, OmegaConf
+
+# isort: on
+import parllel.logger as logger
+
+# isort: split
+from build_parllel_sac import build
+
+
+# fmt: on
+@hydra.main(version_base=None, config_path="conf", config_name="sac_walker_parllel")
+def main(config: DictConfig) -> None:
+    run = wandb.init(
+        project="parllel",
+        tags=["sac", "walker"],
+        config=OmegaConf.to_container(config, resolve=True, throw_on_missing=True),
+        sync_tensorboard=True,  # auto-upload any values logged to tensorboard
+        save_code=True,  # save script used to start training, git commit, and patch
+    )
+
+    logger.init(
+        wandb_run=run,
+        log_dir=HydraConfig.get().runtime.output_dir,
+        tensorboard=True,
+    )
+
+    with build(config) as runner:
+        runner.run()
+
+    logger.close()
+    run.finish()
+
+
+if __name__ == "__main__":
+    mp.set_start_method("forkserver")
+    main()

--- a/benchmarks/sb3/train_sac_walker_sb3.py
+++ b/benchmarks/sb3/train_sac_walker_sb3.py
@@ -1,0 +1,30 @@
+import hydra
+from omegaconf import DictConfig, OmegaConf, open_dict
+
+import wandb
+
+# isort: split
+from build_sb3_sac import build
+
+
+@hydra.main(version_base=None, config_path="conf", config_name="sac_walker_sb3")
+def main(config: DictConfig) -> None:
+    run = wandb.init(
+        project="parllel",
+        tags=["sac", "walker"],
+        config=OmegaConf.to_container(config, resolve=True, throw_on_missing=True),
+        sync_tensorboard=True,  # auto-upload any values logged to tensorboard
+        save_code=True,  # save script used to start training, git commit, and patch
+    )
+
+    with open_dict(config):
+        config["log_dir"] = run.dir  # algo needs to know where to save tensorboard logs
+
+    with build(config) as (model, learn_kwargs):
+        model.learn(**learn_kwargs)
+
+    run.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cartpole/conf/ppo.yaml
+++ b/examples/cartpole/conf/ppo.yaml
@@ -1,12 +1,9 @@
 discount: 0.99
 gae_lambda: 0.95
 normalize_advantage: True
-epochs: 4
-minibatches: 4
 ratio_clip: 0.1
-value_clipping_mode: "none"
 value_loss_coeff: 1.
 entropy_loss_coeff: 0.01
-clip_grad_norm: 1.
+epochs: 4
+minibatches: 4
 learning_rate: 0.001
-learning_rate_scheduler: null

--- a/examples/continuous_cartpole/conf/ppo.yaml
+++ b/examples/continuous_cartpole/conf/ppo.yaml
@@ -1,12 +1,9 @@
 discount: 0.99
 gae_lambda: 0.95
 normalize_advantage: True
-epochs: 4
-minibatches: 4
 ratio_clip: 0.1
-value_clipping_mode: "none"
 value_loss_coeff: 1.
 entropy_loss_coeff: 0.01
-clip_grad_norm: 1.
+epochs: 4
+minibatches: 4
 learning_rate: 0.001
-learning_rate_scheduler: null

--- a/examples/continuous_cartpole/conf/sac.yaml
+++ b/examples/continuous_cartpole/conf/sac.yaml
@@ -1,10 +1,9 @@
 discount: 0.99
-replay_length: 10000
 learning_starts: 0
 replay_ratio: 256
-batch_size: 256
 target_update_tau: 0.005
 target_update_interval: 1
 ent_coeff: 1.e-5
-clip_grad_norm: 1.e+9
+batch_size: 256
 learning_rate: 0.001
+replay_length: 10000

--- a/examples/continuous_cartpole/train_sac.py
+++ b/examples/continuous_cartpole/train_sac.py
@@ -119,28 +119,27 @@ def build(config: DictConfig) -> Iterator[RLRunner]:
         batch_transform=lambda tree: tree.to(device=device),
     )
 
-    optimizers = {
-        "pi": torch.optim.Adam(
-            agent.model["pi"].parameters(),
-            lr=config["algo"]["learning_rate"],
-            **config.get("optimizer", {}),
+    q_optimizer = torch.optim.Adam(
+        itertools.chain(
+            agent.model["q1"].parameters(),
+            agent.model["q2"].parameters(),
         ),
-        "q": torch.optim.Adam(
-            itertools.chain(
-                agent.model["q1"].parameters(),
-                agent.model["q2"].parameters(),
-            ),
-            lr=config["algo"]["learning_rate"],
-            **config.get("optimizer", {}),
-        ),
-    }
+        lr=config["algo"]["learning_rate"],
+        **config.get("optimizer", {}),
+    )
+    pi_optimizer = torch.optim.Adam(
+        agent.model["pi"].parameters(),
+        lr=config["algo"]["learning_rate"],
+        **config.get("optimizer", {}),
+    )
 
     # create algorithm
     algorithm = SAC(
         batch_spec=batch_spec,
         agent=agent,
         replay_buffer=replay_buffer,
-        optimizers=optimizers,
+        q_optimizer=q_optimizer,
+        pi_optimizer=pi_optimizer,
         **config["algo"],
     )
 

--- a/examples/pointcloud_rl/conf/ppo.yaml
+++ b/examples/pointcloud_rl/conf/ppo.yaml
@@ -1,12 +1,9 @@
 discount: 0.99
 gae_lambda: 0.95
 normalize_advantage: True
-epochs: 4
-minibatches: 4
 ratio_clip: 0.1
-value_clipping_mode: "none"
 value_loss_coeff: 1.
 entropy_loss_coeff: 0.01
-clip_grad_norm: 1.
+epochs: 4
+minibatches: 4
 learning_rate: 0.001
-learning_rate_scheduler: null

--- a/examples/pointcloud_rl/conf/sac.yaml
+++ b/examples/pointcloud_rl/conf/sac.yaml
@@ -1,10 +1,9 @@
 discount: 0.99
-replay_length: 10000
 learning_starts: 0
 replay_ratio: 16
-batch_size: 256
 target_update_tau: 0.005
 target_update_interval: 1
 ent_coeff: 1.e-5
-clip_grad_norm: 1.e+9
+batch_size: 256
 learning_rate: 0.001
+replay_length: 10000

--- a/examples/pointcloud_rl/train_sac.py
+++ b/examples/pointcloud_rl/train_sac.py
@@ -139,28 +139,27 @@ def build(config: DictConfig) -> Iterator[RLRunner]:
         batch_transform=batch_transform,
     )
 
-    optimizers = {
-        "pi": torch.optim.Adam(
-            agent.model["pi"].parameters(),
-            lr=config["algo"]["learning_rate"],
-            **config.get("optimizer", {}),
+    q_optimizer = torch.optim.Adam(
+        itertools.chain(
+            agent.model["q1"].parameters(),
+            agent.model["q2"].parameters(),
         ),
-        "q": torch.optim.Adam(
-            itertools.chain(
-                agent.model["q1"].parameters(),
-                agent.model["q2"].parameters(),
-            ),
-            lr=config["algo"]["learning_rate"],
-            **config.get("optimizer", {}),
-        ),
-    }
+        lr=config["algo"]["learning_rate"],
+        **config.get("optimizer", {}),
+    )
+    pi_optimizer = torch.optim.Adam(
+        agent.model["pi"].parameters(),
+        lr=config["algo"]["learning_rate"],
+        **config.get("optimizer", {}),
+    )
 
     # create algorithm
     algorithm = SAC(
         batch_spec=batch_spec,
         agent=agent,
         replay_buffer=replay_buffer,
-        optimizers=optimizers,
+        q_optimizer=q_optimizer,
+        pi_optimizer=pi_optimizer,
         **config["algo"],
     )
 

--- a/parllel/cages/cage.py
+++ b/parllel/cages/cage.py
@@ -26,9 +26,6 @@ class Cage(ABC):
     immediately when done is True, replacing the returned observation with the
     reset observation. If False, environment is not reset and the
     `needs_reset` flag is set to True.
-    ;param ignore_reset_info (bool): If True (default), the info dictionary
-    returned by env.reset() gets ignored. If False, the dict is treated the
-    same way as info dicts returned by env.step() calls
     """
 
     def __init__(
@@ -37,13 +34,11 @@ class Cage(ABC):
         env_kwargs: Mapping[str, Any],
         TrajInfoClass: Callable,
         reset_automatically: bool = True,
-        ignore_reset_info: bool = True,
     ) -> None:
         self.EnvClass = EnvClass
         self.env_kwargs = env_kwargs
         self.TrajInfoClass = TrajInfoClass
         self.reset_automatically = reset_automatically
-        self.ignore_reset_info = ignore_reset_info
 
         self._needs_reset: bool = False
         self._render: bool = False

--- a/parllel/cages/process.py
+++ b/parllel/cages/process.py
@@ -46,9 +46,6 @@ class ProcessCage(Cage, mp.Process):
     immediately when done is True, replacing the returned observation with the
     reset observation. If False, environment is not reset and the
     `needs_reset` flag is set to True.
-    :param ignore_reset_info (bool): If True (default), the info dictionary
-    returned by env.reset() gets ignored. If False, the dict is treated the
-    same way as info dicts returned by env.step() calls
     """
 
     # TODO: add spaces and needs_reset properties
@@ -59,7 +56,6 @@ class ProcessCage(Cage, mp.Process):
         env_kwargs: dict[str, Any],
         TrajInfoClass: Callable,
         reset_automatically: bool = False,
-        ignore_reset_info: bool = True,
     ) -> None:
         mp.Process.__init__(self)
 
@@ -68,7 +64,6 @@ class ProcessCage(Cage, mp.Process):
             env_kwargs=env_kwargs,
             TrajInfoClass=TrajInfoClass,
             reset_automatically=reset_automatically,
-            ignore_reset_info=ignore_reset_info,
         )
 
         # pipe is used for communication between main and child processes

--- a/parllel/cages/serial.py
+++ b/parllel/cages/serial.py
@@ -21,9 +21,6 @@ class SerialCage(Cage):
     immediately when done is True, replacing the returned observation with the
     reset observation. If False, environment is not reset and the
     `needs_reset` flag is set to True.
-    ;param ignore_reset_info (bool): If True (default), the info dictionary
-    returned by env.reset() gets ignored. If False, the dict is treated the
-    same way as info dicts returned by env.step() calls
     """
 
     def __init__(
@@ -32,14 +29,12 @@ class SerialCage(Cage):
         env_kwargs: dict[str, Any],
         TrajInfoClass: Callable,
         reset_automatically: bool = True,
-        ignore_reset_info: bool = True,
     ) -> None:
         super().__init__(
             EnvClass=EnvClass,
             env_kwargs=env_kwargs,
             TrajInfoClass=TrajInfoClass,
             reset_automatically=reset_automatically,
-            ignore_reset_info=ignore_reset_info,
         )
         # create env immediately in the local process
         self._create_env()

--- a/parllel/cages/serial.py
+++ b/parllel/cages/serial.py
@@ -55,6 +55,7 @@ class SerialCage(Cage):
         out_terminated: Array | None = None,
         out_truncated: Array | None = None,
         out_info: ArrayTree[Array] | None = None,
+        out_reset_info: ArrayTree[Array] | None = None,
     ) -> None:
         next_obs, reward, terminated, truncated, env_info = self._step_env(action)
         obs = next_obs
@@ -63,48 +64,36 @@ class SerialCage(Cage):
             if self.reset_automatically:
                 # reset immediately and overwrite last observation and info
                 obs, reset_info = self._reset_env()
-                if not self.ignore_reset_info:
-                    env_info = reset_info
+                if out_reset_info is not None:
+                    out_reset_info[...] = reset_info
             else:
                 # store done state
                 self._needs_reset = True
 
-        try:
-            out_next_obs[...] = next_obs
-            out_obs[...] = obs
-            out_reward[...] = reward
-            out_terminated[...] = terminated
-            out_truncated[...] = truncated
-            out_info[...] = env_info
-        except TypeError as e:
-            outs = (
-                out_next_obs,
-                out_obs,
-                out_reward,
-                out_terminated,
-                out_truncated,
-                out_info,
-            )
-            # TODO: make out arguments optional
-            if any(out is None for out in outs):
-                if not all(out is None for out in outs):
-                    # if user passed a combination of None and Array, it's probably a mistake
-                    raise ValueError(
-                        f"Missing {outs.index(None) + 1}nth output argument!"
-                    )
+        out_pairs = (
+            (out_next_obs, next_obs),
+            (out_obs, obs),
+            (out_reward, reward),
+            (out_terminated, terminated),
+            (out_truncated, truncated),
+            (out_info, env_info),
+        )
 
-                # return step result if user passed no output args at all
-                self._step_result = (
-                    next_obs,
-                    obs,
-                    reward,
-                    terminated,
-                    truncated,
-                    env_info,
-                )
-            else:
-                # otherwise this was an unexpected error
-                raise e
+        if pairs_to_write := [
+            (out, result) for out, result in out_pairs if out is not None
+        ]:
+            for out, result in pairs_to_write:
+                out[...] = result
+        else:
+            # return step result if user passed no output args at all
+            self._step_result = (
+                next_obs,
+                obs,
+                reward,
+                terminated,
+                truncated,
+                env_info,
+            )
 
     def await_step(self) -> EnvStepType | EnvRandomStepType | EnvResetType | None:
         result = self._step_result
@@ -126,6 +115,7 @@ class SerialCage(Cage):
         out_terminated: Array | None = None,
         out_truncated: Array | None = None,
         out_info: ArrayTree[Array] | None = None,
+        out_reset_info: ArrayTree[Array] | None = None,
     ) -> None:
         (
             action,
@@ -140,48 +130,35 @@ class SerialCage(Cage):
         if terminated or truncated:
             # reset immediately and overwrite last observation
             obs, reset_info = self._reset_env()
-            if not self.ignore_reset_info:
-                env_info = reset_info
+            if out_reset_info is not None:
+                out_reset_info[...] = reset_info
 
-        try:
-            out_action[...] = action
-            out_next_obs[...] = next_obs
-            out_obs[...] = obs
-            out_reward[...] = reward
-            out_terminated[...] = terminated
-            out_truncated[...] = truncated
-            out_info[...] = env_info
-        except TypeError as e:
-            # TODO: make out arguments optional
-            outs = (
-                out_action,
-                out_next_obs,
-                out_obs,
-                out_reward,
-                out_terminated,
-                out_truncated,
-                out_info,
+        out_pairs = (
+            (out_action, action),
+            (out_next_obs, next_obs),
+            (out_obs, obs),
+            (out_reward, reward),
+            (out_terminated, terminated),
+            (out_truncated, truncated),
+            (out_info, env_info),
+        )
+
+        if pairs_to_write := [
+            (out, result) for out, result in out_pairs if out is not None
+        ]:
+            for out, result in pairs_to_write:
+                out[...] = result
+        else:
+            # return step result if user passed no output args at all
+            self._step_result = (
+                action,
+                next_obs,
+                obs,
+                reward,
+                terminated,
+                truncated,
+                env_info,
             )
-            if any(out is None for out in outs):
-                if not all(out is None for out in outs):
-                    # if user passed a combination of None and Array, it's probably a mistake
-                    raise ValueError(
-                        f"Missing {outs.index(None) + 1}nth output argument!"
-                    )
-
-                # return step result if user passed no output args at all
-                self._step_result = (
-                    action,
-                    next_obs,
-                    obs,
-                    reward,
-                    terminated,
-                    truncated,
-                    env_info,
-                )
-            else:
-                # otherwise this was an unexpected error
-                raise e
 
     def reset_async(
         self,
@@ -192,24 +169,13 @@ class SerialCage(Cage):
         reset_obs, reset_info = self._reset_env()
         self._needs_reset = False
 
-        try:
+        if out_obs is not None:
             out_obs[...] = reset_obs
-            if not self.ignore_reset_info:
-                out_info[...] = reset_info
-        except TypeError as e:
-            outs = (out_obs, out_info)
-            if any(out is None for out in outs):
-                if not all(out is None for out in outs):
-                    # if user passed a combination of None and Array, it's probably a mistake
-                    raise ValueError(
-                        f"Missing {outs.index(None) + 1}nth output argument!"
-                    )
-
-                # return step result if user passed no output args at all
-                self._step_result = (reset_obs, reset_info)
-            else:
-                # otherwise this was an unexpected error
-                raise e
+        if out_info is not None:
+            out_info[...] = reset_info
+        if out_obs is None and out_info is None:
+            # return step result if user passed no output args at all
+            self._step_result = (reset_obs, reset_info)
 
     def close(self) -> None:
         self._close_env()

--- a/parllel/logger/logger.py
+++ b/parllel/logger/logger.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+from gymnasium.utils import colorize
 
 try:
     import wandb
@@ -360,7 +361,7 @@ class Logger:
             #         policy="now",
             #     )
 
-    def log(self, *args, level: Verbosity = Verbosity.INFO) -> None:
+    def log(self, msg: str, level: Verbosity = Verbosity.INFO) -> None:
         """
         Write the sequence of args, with no separators,
         to the console and output files (if you've configured an output file).
@@ -374,9 +375,9 @@ class Logger:
         if self.verbosity >= level:
             for writer in self.writers.values():
                 if isinstance(writer, MessageWriter):
-                    writer.write_message(map(str, args))
+                    writer.write_message(msg)
 
-    def debug(self, *args) -> None:
+    def debug(self, msg: str, *args) -> None:
         """
         Write the sequence of args, with no separators,
         to the console and output files (if you've configured an output file).
@@ -384,9 +385,9 @@ class Logger:
 
         :param args: log the arguments
         """
-        self.log(*args, level=Verbosity.DEBUG)
+        self.log(msg % args, level=Verbosity.DEBUG)
 
-    def info(self, *args) -> None:
+    def info(self, msg: str, *args) -> None:
         """
         Write the sequence of args, with no separators,
         to the console and output files (if you've configured an output file).
@@ -394,9 +395,9 @@ class Logger:
 
         :param args: log the arguments
         """
-        self.log(*args, level=Verbosity.INFO)
+        self.log(msg % args, level=Verbosity.INFO)
 
-    def warn(self, *args) -> None:
+    def warn(self, msg: str, *args) -> None:
         """
         Write the sequence of args, with no separators,
         to the console and output files (if you've configured an output file).
@@ -404,10 +405,10 @@ class Logger:
 
         :param args: log the arguments
         """
-        self.log("WARNING:", *args, level=Verbosity.WARN)
+        self.log(colorize(f"WARNING: {msg % args}", "yellow"), level=Verbosity.WARN)
         # TODO: throw warning, maybe with warnings module
 
-    def error(self, *args) -> None:
+    def error(self, msg: str, *args) -> None:
         """
         Write the sequence of args, with no separators,
         to the console and output files (if you've configured an output file).
@@ -415,8 +416,7 @@ class Logger:
 
         :param args: log the arguments
         """
-        self.log("ERROR:", *args, level=Verbosity.ERROR)
-        # TODO: throw runtime exception here?
+        self.log(colorize(f"ERROR: {msg % args}", "red"), level=Verbosity.ERROR)
 
     def set_verbosity(self, verbosity: Verbosity) -> None:
         """

--- a/parllel/logger/logwriters.py
+++ b/parllel/logger/logwriters.py
@@ -164,12 +164,11 @@ class MessageWriter:
     `logger.warn`.
     """
 
-    def write_message(self, sequence: Sequence) -> None:
+    def write_message(self, message: str) -> None:
         """
         Write a message to the log file.
 
-        :param sequence:
-        # TODO: update these parameters and type hints
+        :param message: string message to print
         """
         raise NotImplementedError
 
@@ -261,13 +260,8 @@ class TxtFileWriter(KeyValueWriter, MessageWriter, LogWriter, name="txt"):
             string = string[: self.max_length - 3] + "..."
         return string
 
-    def write_message(self, sequence: Sequence) -> None:
-        sequence = list(sequence)
-        for i, elem in enumerate(sequence):
-            self.file.write(elem)
-            if i < len(sequence) - 1:  # add space unless this is the last one
-                self.file.write(" ")
-        self.file.write("\n")
+    def write_message(self, message: str) -> None:
+        self.file.write(message + "\n")
         self.file.flush()
 
     def close(self) -> None:

--- a/parllel/patterns.py
+++ b/parllel/patterns.py
@@ -406,14 +406,10 @@ def build_eval_sampler(
     # first, collect only the keys needed for evaluation
     eval_tree_keys = [
         "action",
-        "agent_info",
-        "next_observation",
         "observation",
-        "reward",
         "terminated",
         "truncated",
         "done",
-        "env_info",
     ]
     eval_tree_example = ArrayDict(
         {key: sample_tree[key] for key in eval_tree_keys},

--- a/parllel/samplers/basic.py
+++ b/parllel/samplers/basic.py
@@ -63,6 +63,7 @@ class BasicSampler(Sampler):
         # get references to sample tree elements
         action = self.sample_tree["action"]
         agent_info = self.sample_tree["agent_info"]
+        next_observation = self.sample_tree["next_observation"]
         observation = self.sample_tree["observation"]
         reward = self.sample_tree["reward"]
         done = self.sample_tree["done"]
@@ -89,6 +90,7 @@ class BasicSampler(Sampler):
             for b, env in enumerate(self.envs):
                 env.step_async(
                     action[t, b],
+                    out_next_obs=next_observation[t, b],
                     out_obs=observation[t + 1, b],
                     out_reward=reward[t, b],
                     out_terminated=terminated[t, b],

--- a/parllel/samplers/basic.py
+++ b/parllel/samplers/basic.py
@@ -24,7 +24,7 @@ class BasicSampler(Sampler):
         envs: Sequence[Cage],
         agent: Agent,
         sample_tree: ArrayDict[Array],
-        max_steps_decorrelate: int | None = None,
+        max_steps_decorrelate: int | None = 0,
         get_bootstrap_value: bool = False,
         obs_transform: StepTransform | None = None,
         batch_transform: BatchTransform | None = None,

--- a/parllel/samplers/eval.py
+++ b/parllel/samplers/eval.py
@@ -45,6 +45,7 @@ class EvalSampler(Sampler):
         # get references to sample tree elements
         action = self.sample_tree["action"]
         agent_info = self.sample_tree["agent_info"]
+        next_observation = self.sample_tree["next_observation"]
         observation = self.sample_tree["observation"]
         reward = self.sample_tree["reward"]
         done = self.sample_tree["done"]
@@ -78,6 +79,7 @@ class EvalSampler(Sampler):
             for b, env in enumerate(self.envs):
                 env.step_async(
                     action[0, b],
+                    out_next_obs=next_observation[0, b],
                     out_obs=observation[0, b],
                     out_reward=reward[0, b],
                     out_terminated=terminated[0, b],

--- a/parllel/samplers/recurrent.py
+++ b/parllel/samplers/recurrent.py
@@ -157,7 +157,6 @@ class RecurrentSampler(Sampler):
             # overwrite next first observation with reset observation
             env.reset_async(
                 out_obs=observation[self.batch_spec.T, b],
-                out_info=env_info[self.batch_spec.T - 1, b],
             )
 
         self.agent.reset_one([b for b, env in envs_need_reset])

--- a/parllel/samplers/recurrent.py
+++ b/parllel/samplers/recurrent.py
@@ -20,7 +20,7 @@ class RecurrentSampler(Sampler):
         envs: Sequence[Cage],
         agent: Agent,
         sample_tree: ArrayDict[Array],
-        max_steps_decorrelate: int | None = None,
+        max_steps_decorrelate: int | None = 0,
         get_initial_rnn_state: bool = True,
         get_bootstrap_value: bool = False,
         obs_transform: StepTransform | None = None,

--- a/parllel/samplers/sampler.py
+++ b/parllel/samplers/sampler.py
@@ -20,7 +20,7 @@ class Sampler(ABC):
         envs: Sequence[Cage],
         agent: Agent,
         sample_tree: ArrayDict[Array],
-        max_steps_decorrelate: int | None = None,
+        max_steps_decorrelate: int | None = 0,
     ) -> None:
         self.batch_spec = batch_spec
 
@@ -46,7 +46,7 @@ class Sampler(ABC):
         """Prepare environments, agents and sample tree for sampling."""
         self.reset_envs()
         if self.max_steps_decorrelate > 0:
-            self.decorrelate_environments()
+            self.decorrelate_environments(self.max_steps_decorrelate)
         self.reset_agent()
 
     def reset_envs(self) -> None:
@@ -58,7 +58,6 @@ class Sampler(ABC):
         self.sample_tree.reset()
         logger.info(f"{type(self).__name__}: Resetting all environments.")
         observation = self.sample_tree["observation"]
-        env_info = self.sample_tree["env_info"]
         for b, env in enumerate(self.envs):
             # save reset observation to the end of sample tree, since it will
             # be rotated to the beginning
@@ -81,11 +80,11 @@ class Sampler(ABC):
     def seed(self, seed) -> None:
         self.rng = random.default_rng(seed)
 
-    def decorrelate_environments(self) -> None:
+    def decorrelate_environments(self, max_steps: int) -> None:
         """Randomly step environments so they are not all synced up."""
         logger.info(
             f"{type(self).__name__}: Decorrelating environments with up to "
-            f"{self.max_steps_decorrelate} random steps each."
+            f"{max_steps} random steps each."
         )
         # get references to sample tree elements
         action = self.sample_tree["action"]
@@ -100,13 +99,13 @@ class Sampler(ABC):
         # get random number of steps between 0 and max for each env
         n_random_steps = self.rng.integers(
             low=0,
-            high=self.max_steps_decorrelate,
+            high=max_steps,
             size=len(self.envs),
             dtype=np.int32,
         )
 
         env_to_step = list(enumerate(self.envs))
-        for t in range(self.max_steps_decorrelate):
+        for t in range(max_steps):
             # filter out any environments that don't need to be stepped anymore
             env_to_step = [(b, env) for b, env in env_to_step if t <= n_random_steps[b]]
 

--- a/parllel/samplers/sampler.py
+++ b/parllel/samplers/sampler.py
@@ -64,7 +64,6 @@ class Sampler(ABC):
             # be rotated to the beginning
             env.reset_async(
                 out_obs=observation[self.batch_spec.T, b],
-                out_info=env_info[self.batch_spec.T, b],
             )
 
         # wait for envs to finish reset

--- a/parllel/samplers/tests/test_basic.py
+++ b/parllel/samplers/tests/test_basic.py
@@ -136,12 +136,17 @@ def sample_tree(
 ):
     # get example output from env
     envs[0].random_step_async()
-    action, obs, reward, terminated, truncated, info = envs[0].await_step()
+    action, next_obs, obs, reward, terminated, truncated, info = envs[0].await_step()
     agent_info = agent.get_agent_info()
 
     sample_tree: ArrayDict[Array] = ArrayDict()
 
     # allocate sample tree based on examples
+    sample_tree["next_observation"] = dict_map(
+        Array.from_numpy,
+        next_obs,
+        batch_shape=tuple(batch_spec),
+    )
     sample_tree["observation"] = dict_map(
         Array.from_numpy,
         obs,

--- a/parllel/samplers/tests/test_recurrent.py
+++ b/parllel/samplers/tests/test_recurrent.py
@@ -8,10 +8,15 @@ from parllel.cages import Cage, MultiAgentTrajInfo, SerialCage, TrajInfo
 from parllel.samplers.recurrent import RecurrentSampler
 from parllel.samplers.tests.dummy_agent import DummyAgent
 from parllel.samplers.tests.dummy_env import DummyEnv
-from parllel.samplers.tests.test_basic import (N_BATCHES, action_space,
-                                               batch_spec, get_bootstrap,
-                                               max_decorrelation_steps,
-                                               multireward, observation_space)
+from parllel.samplers.tests.test_basic import (
+    N_BATCHES,
+    action_space,
+    batch_spec,
+    get_bootstrap,
+    max_decorrelation_steps,
+    multireward,
+    observation_space,
+)
 from parllel.tree.utils import assert_dict_equal
 
 
@@ -76,7 +81,7 @@ def sample_tree(
 ):
     # get example output from env
     envs[0].random_step_async()
-    action, obs, reward, terminated, truncated, info = envs[0].await_step()
+    action, next_obs, obs, reward, terminated, truncated, info = envs[0].await_step()
     agent_info = agent.get_agent_info()
 
     sample_tree: ArrayDict[Array] = ArrayDict()
@@ -205,9 +210,7 @@ class TestRecurrentSampler:
 
         for i, batch in enumerate(batches):
             # verify rnn_states
-            assert_dict_equal(
-                batch["initial_rnn_state"], agent.initial_rnn_states[i]
-            )
+            assert_dict_equal(batch["initial_rnn_state"], agent.initial_rnn_states[i])
             # remove because it cannot be indexed in time
             batch.pop("initial_rnn_state")
 
@@ -232,7 +235,7 @@ class TestRecurrentSampler:
             done_envs = np.any(batch["done"], axis=0)
             assert np.array_equal(agent.resets[time_slice][batch_spec.T - 1], done_envs)
             # check that the agent was only reset at the end of the batch
-            assert not np.any(agent.resets[time_slice][:batch_spec.T - 1])
+            assert not np.any(agent.resets[time_slice][: batch_spec.T - 1])
 
             # check that agent state is 0 at beginning of next batch for those
             # environments that were done during this batch
@@ -258,18 +261,19 @@ class TestRecurrentSampler:
 
                 # verify that the env saw the correct action at each step
                 assert_dict_equal(
-                    dict_map(np.asarray, env._env.samples["env_info"]["action"][time_slice])[
-                        b_valid
-                    ],
+                    dict_map(
+                        np.asarray, env._env.samples["env_info"]["action"][time_slice]
+                    )[b_valid],
                     dict_map(np.asarray, batch["action"][:, b])[b_valid],
                     f"batch{(i+1)}_action",
                 )
 
                 # verify that the agent saw the correct observation at each step
                 assert_dict_equal(
-                    dict_map(np.asarray, agent.samples["agent_info"]["observation"][time_slice, b])[
-                        b_valid
-                    ],
+                    dict_map(
+                        np.asarray,
+                        agent.samples["agent_info"]["observation"][time_slice, b],
+                    )[b_valid],
                     dict_map(np.asarray, batch["observation"][:, b])[b_valid],
                     f"batch{(i+1)}_observation",
                 )

--- a/parllel/torch/algos/ppo.py
+++ b/parllel/torch/algos/ppo.py
@@ -236,12 +236,12 @@ def build_loss_sample_tree(
 
     # move these to the top level for convenience
     # anything else in agent_info is agent-specific state
-    loss_sample_tree["old_value"] = loss_sample_tree["agent_info"].pop("value")
-    loss_sample_tree["old_dist_params"] = loss_sample_tree["agent_info"].pop(
-        "dist_params"
-    )
+    agent_info = loss_sample_tree["agent_info"]
+    loss_sample_tree["old_value"] = agent_info.pop("value")
+    loss_sample_tree["old_dist_params"] = agent_info.pop("dist_params")
 
     if "valid" in sample_tree:
+        # assume agent/model is recurrent
         loss_sample_tree["valid"] = sample_tree["valid"]
         assert "initial_rnn_state" in sample_tree
         loss_sample_tree["initial_rnn_state"] = sample_tree["initial_rnn_state"]

--- a/parllel/torch/algos/ppo.py
+++ b/parllel/torch/algos/ppo.py
@@ -13,7 +13,7 @@ import parllel.logger as logger
 from parllel import Array, ArrayDict
 from parllel.algorithm import Algorithm
 from parllel.replays import BatchedDataLoader
-from parllel.torch.agents.pg import PgPrediction, PgAgent
+from parllel.torch.agents.pg import PgAgent, PgPrediction
 from parllel.torch.utils import explained_variance, valid_mean
 
 
@@ -34,13 +34,13 @@ class PPO(Algorithm):
         agent: PgAgent,
         dataloader: BatchedDataLoader[ArrayDict[Tensor]],
         optimizer: Optimizer,
-        learning_rate_scheduler: _LRScheduler | None,
+        ratio_clip: float,
         value_loss_coeff: float,
         entropy_loss_coeff: float,
-        clip_grad_norm: float | None,
         epochs: int,
-        ratio_clip: float,
-        value_clipping_mode: Literal["none", "ratio", "delta", "delta_max"],
+        clip_grad_norm: float | None = None,
+        learning_rate_scheduler: _LRScheduler | None = None,
+        value_clipping_mode: Literal["ratio", "delta", "delta_max"] | None = None,
         value_clip: float | None = None,
         kl_divergence_limit: float = np.inf,
         **kwargs,  # ignore additional arguments
@@ -49,17 +49,18 @@ class PPO(Algorithm):
         self.agent = agent
         self.dataloader = dataloader
         self.optimizer = optimizer
-        self.lr_scheduler = learning_rate_scheduler
+        self.ratio_clip = ratio_clip
         self.value_loss_coeff = value_loss_coeff
         self.entropy_loss_coeff = entropy_loss_coeff
-        self.clip_grad_norm = clip_grad_norm
         self.epochs = epochs
-        self.ratio_clip = ratio_clip
+        self.clip_grad_norm = clip_grad_norm
+        self.lr_scheduler = learning_rate_scheduler
         self.value_clipping_mode = value_clipping_mode
         self.kl_divergence_limit = kl_divergence_limit
 
         if self.value_clipping_mode in ("ratio", "delta", "delta_max"):
-            assert value_clip is not None
+            if value_clip is None:
+                raise ValueError("Must specify value clip.")
             self.value_clip = value_clip
 
         self.update_counter = 0
@@ -138,7 +139,7 @@ class PPO(Algorithm):
         surrogate = torch.min(surr_1, surr_2)
         pi_loss = -valid_mean(surrogate, valid)
 
-        if self.value_clipping_mode == "none":
+        if self.value_clipping_mode is None:
             # No clipping
             value_error = 0.5 * (value - batch["return_"]) ** 2
         elif self.value_clipping_mode == "ratio":
@@ -236,8 +237,10 @@ def build_loss_sample_tree(
     # move these to the top level for convenience
     # anything else in agent_info is agent-specific state
     loss_sample_tree["old_value"] = loss_sample_tree["agent_info"].pop("value")
-    loss_sample_tree["old_dist_params"] = loss_sample_tree["agent_info"].pop("dist_params")
-    
+    loss_sample_tree["old_dist_params"] = loss_sample_tree["agent_info"].pop(
+        "dist_params"
+    )
+
     if "valid" in sample_tree:
         loss_sample_tree["valid"] = sample_tree["valid"]
         assert "initial_rnn_state" in sample_tree

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Mapping
+from typing import Sequence
 
 import torch
 from torch import Tensor
 from torch.nn.utils.clip_grad import clip_grad_norm_
+from torch.optim.lr_scheduler import LRScheduler
 
 import parllel.logger as logger
 from parllel import Array, ArrayDict
@@ -24,7 +25,8 @@ class SAC(Algorithm):
         batch_spec: BatchSpec,
         agent: SacAgent,
         replay_buffer: ReplayBuffer[ArrayDict[Tensor]],
-        optimizers: Mapping[str, torch.optim.Optimizer],
+        q_optimizer: torch.optim.Optimizer,
+        pi_optimizer: torch.optim.Optimizer,
         discount: float,
         learning_starts: int,
         replay_ratio: int,  # data_consumption / data_generation
@@ -32,18 +34,21 @@ class SAC(Algorithm):
         target_update_interval: int,  # 1000 for hard update, 1 for soft.
         ent_coeff: float,
         clip_grad_norm: float | None = None,
+        learning_rate_schedulers: Sequence[LRScheduler] | None = None,
         **kwargs,  # ignore additional arguments
     ):
         """Save input arguments."""
         self.agent = agent
         self.replay_buffer = replay_buffer
-        self.optimizers = optimizers
+        self.q_optimizer = q_optimizer
+        self.pi_optimizer = pi_optimizer
         self.discount = discount
         self.learning_starts = int(learning_starts)
         self.replay_ratio = replay_ratio
         self.target_update_tau = target_update_tau
         self.target_update_interval = target_update_interval
         self.clip_grad_norm = clip_grad_norm
+        self.lr_schedulers = learning_rate_schedulers
 
         replay_batch_size = self.replay_buffer.replay_batch_size
         self.updates_per_optimize = int(
@@ -94,7 +99,15 @@ class SAC(Algorithm):
             if self.update_counter % self.target_update_interval == 0:
                 self.agent.update_target(self.target_update_tau)
 
-            self.algo_log_info["n_updates"] = self.update_counter
+        if self.lr_schedulers is not None:
+            for lr_scheduler in self.lr_schedulers:
+                lr_scheduler.step()
+            # fmt: off
+            self.algo_log_info["pi_learning_rate"] = self.pi_optimizer.param_groups[0]["lr"]
+            self.algo_log_info["q_learning_rate"] = self.q_optimizer.param_groups[0]["lr"]
+            # fmt: on
+
+        self.algo_log_info["n_updates"] = self.update_counter
 
         return self.algo_log_info
 
@@ -128,7 +141,7 @@ class SAC(Algorithm):
         self.algo_log_info["critic_loss"].append(q_loss.item())
 
         # update Q model parameters according to Q loss
-        self.optimizers["q"].zero_grad()
+        self.q_optimizer.zero_grad()
         q_loss.backward()
 
         if self.clip_grad_norm is not None:
@@ -143,7 +156,7 @@ class SAC(Algorithm):
             self.algo_log_info["q1_grad_norm"].append(q1_grad_norm.item())
             self.algo_log_info["q2_grad_norm"].append(q2_grad_norm.item())
 
-        self.optimizers["q"].step()
+        self.q_optimizer.step()
 
         # freeze Q models while optimizing policy model
         self.agent.freeze_q_models(True)
@@ -159,7 +172,7 @@ class SAC(Algorithm):
         self.algo_log_info["actor_loss"].append(pi_loss.item())
 
         # update Pi model parameters according to pi loss
-        self.optimizers["pi"].zero_grad()
+        self.pi_optimizer.zero_grad()
         pi_loss.backward()
 
         if self.clip_grad_norm is not None:
@@ -169,7 +182,7 @@ class SAC(Algorithm):
             )
             self.algo_log_info["pi_grad_norm"].append(pi_grad_norm.item())
 
-        self.optimizers["pi"].step()
+        self.pi_optimizer.step()
 
         # unfreeze Q models for next training iteration
         self.agent.freeze_q_models(False)

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -122,7 +122,7 @@ class SAC(Algorithm):
             target_q1, target_q2 = self.agent.target_q(next_observation, next_action)
         min_target_q = torch.min(target_q1, target_q2)
         next_q = min_target_q - self._alpha * next_log_prob
-        y = samples["reward"] + self.discount * ~samples["done"] * next_q
+        y = samples["reward"] + self.discount * ~samples["terminated"] * next_q
         q1, q2 = self.agent.q(observation.detach(), samples["action"])
         q_loss = 0.5 * valid_mean((y - q1) ** 2 + (y - q2) ** 2)
         self.algo_log_info["critic_loss"].append(q_loss.item())
@@ -181,8 +181,8 @@ def build_replay_buffer_tree(sample_buffer: ArrayDict[Array]) -> ArrayDict[Array
             "observation": sample_buffer["observation"].full,
             "action": sample_buffer["action"].full,
             "reward": sample_buffer["reward"].full,
-            "done": sample_buffer["done"].full,
-            "next_observation": sample_buffer["observation"].full.next,
+            "terminated": sample_buffer["terminated"].full,
+            "next_observation": sample_buffer["next_observation"].full,
         }
     )
     return replay_buffer_tree


### PR DESCRIPTION
Add out_next_obs to output args in step_async and random_step_async.
Cages can be given arbitrary output args, does not need to be all or none.
Add out_reset_info parameter instead of ignore_reset_info constructor argument.
Add next_observation to BasicSampler. Remove unused fields from EvalSampler.
Switch SAC to use terminated as bootstrapping signal, update patterns.
Add learning rate scheduler to SAC, split optimizer dict into two optimizer args.
Add default arguments to PPO and SAC where to corresponds to a no-op.
Add colorization to logger warn and error.
Add walker2d to SB3 benchmarks, factor out common config data.