### PR TITLE
Fix JaggedArrayList.tolist() for fancy indexing.

### DIFF
--- a/parllel/arrays/jagged_list.py
+++ b/parllel/arrays/jagged_list.py
@@ -179,13 +179,14 @@ class JaggedArrayList(JaggedArray):  # do not register subclass
         elif isinstance(t_index, np.ndarray):
             graphs = []
             num_elements = []
-            for i, array in enumerate(self.jagged_arrays):
-                mask = array_idx == i
+            for i, a_idx in enumerate(array_idx):
                 new_current_location = tuple(
-                    loc[mask] if isinstance(loc, np.ndarray) else loc
+                    int(loc[i]) if isinstance(loc, np.ndarray) else loc
                     for loc in current_location
                 )
-                new_graphs, new_nums = array[new_current_location].to_list()
+                new_graphs, new_nums = self.jagged_arrays[a_idx][
+                    new_current_location
+                ].to_list()
                 graphs.extend(new_graphs)
                 num_elements.extend(new_nums)
 

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -52,7 +52,7 @@ class SAC(Algorithm):
 
         replay_batch_size = self.replay_buffer.replay_batch_size
         self.updates_per_optimize = int(
-            self.replay_ratio * batch_spec.size / replay_batch_size
+            max(1, self.replay_ratio * batch_spec.size / replay_batch_size)
         )
         logger.info(
             f"{type(self).__name__}: From sampler batch size {batch_spec.size}, "


### PR DESCRIPTION
Previously, the order was not compared when ndarrays were used to index.
Lower bound SAC updates per optimize at 1.