### PR TITLE
Add learnable entropy coefficient to SAC

### DIFF
--- a/examples/continuous_cartpole/conf/sac.yaml
+++ b/examples/continuous_cartpole/conf/sac.yaml
@@ -3,7 +3,8 @@ learning_starts: 0
 replay_ratio: 256
 target_update_tau: 0.005
 target_update_interval: 1
-ent_coeff: 1.e-5
+ent_coeff: 0.1
 batch_size: 256
 learning_rate: 0.001
+ent_coeff_lr: 0.001
 replay_size: 100000

--- a/examples/continuous_cartpole/models/sac_q_and_pi.py
+++ b/examples/continuous_cartpole/models/sac_q_and_pi.py
@@ -25,6 +25,7 @@ class PiMlpModel(nn.Module):
         assert isinstance(obs_space, spaces.Box)
         assert len(obs_space.shape) == 1
         obs_size = obs_space.shape[0]
+        self.action_space = action_space
 
         assert isinstance(action_space, spaces.Box)
         assert len(action_space.shape) == 1

--- a/examples/continuous_cartpole/models/sac_q_and_pi.py
+++ b/examples/continuous_cartpole/models/sac_q_and_pi.py
@@ -25,7 +25,6 @@ class PiMlpModel(nn.Module):
         assert isinstance(obs_space, spaces.Box)
         assert len(obs_space.shape) == 1
         obs_size = obs_space.shape[0]
-        self.action_space = action_space
 
         assert isinstance(action_space, spaces.Box)
         assert len(action_space.shape) == 1

--- a/examples/continuous_cartpole/train_sac.py
+++ b/examples/continuous_cartpole/train_sac.py
@@ -153,6 +153,7 @@ def build(config: DictConfig) -> Iterator[RLRunner]:
         replay_buffer=replay_buffer,
         q_optimizer=q_optimizer,
         pi_optimizer=pi_optimizer,
+        action_space=action_space,
         **config["algo"],
     )
 

--- a/examples/pointcloud_rl/conf/sac.yaml
+++ b/examples/pointcloud_rl/conf/sac.yaml
@@ -3,7 +3,8 @@ learning_starts: 0
 replay_ratio: 16
 target_update_tau: 0.005
 target_update_interval: 1
-ent_coeff: 1.e-5
+ent_coeff: 0.1
 batch_size: 256
 learning_rate: 0.001
+ent_coeff_lr: 0.001
 replay_size: 100000

--- a/examples/pointcloud_rl/train_sac.py
+++ b/examples/pointcloud_rl/train_sac.py
@@ -180,6 +180,7 @@ def build(config: DictConfig) -> Iterator[RLRunner]:
         replay_buffer=replay_buffer,
         q_optimizer=q_optimizer,
         pi_optimizer=pi_optimizer,
+        action_space=action_space,
         **config["algo"],
     )
 

--- a/parllel/torch/agents/sac_agent.py
+++ b/parllel/torch/agents/sac_agent.py
@@ -120,6 +120,10 @@ class SacAgent(TorchAgent):
     def update_target(self, tau: float | int = 1) -> None:
         update_state_dict(self.model["target_q1"], self.model["q1"].state_dict(), tau)
         update_state_dict(self.model["target_q2"], self.model["q2"].state_dict(), tau)
+        if "target_encoder" in self.model:
+            update_state_dict(
+                self.model["target_encoder"], self.model["encoder"].state_dict(), tau
+            )
 
     def train_mode(self, elapsed_steps: int) -> None:
         super().train_mode(elapsed_steps)

--- a/parllel/torch/agents/sac_agent.py
+++ b/parllel/torch/agents/sac_agent.py
@@ -43,6 +43,10 @@ class SacAgent(TorchAgent):
         model["target_q2"] = copy.deepcopy(model["q2"])
         model["target_q2"].requires_grad_(False)
 
+        if "encoder" in model:
+            model["target_encoder"] = copy.deepcopy(model["encoder"])
+            model["target_encoder"].requires_grad_(False)
+
         super().__init__(model, distribution, device)
 
         self.learning_starts = learning_starts
@@ -53,6 +57,11 @@ class SacAgent(TorchAgent):
     def encode(self, observation: ArrayTree[Tensor]) -> ArrayTree[Tensor]:
         if "encoder" in self.model:
             observation = self.model["encoder"](observation)
+        return observation
+
+    def target_encode(self, observation: ArrayTree[Tensor]) -> ArrayTree[Tensor]:
+        if "target_encoder" in self.model:
+            observation = self.model["target_encoder"](observation)
         return observation
 
     @torch.no_grad()

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -66,8 +66,6 @@ class SAC(Algorithm):
         self.update_counter = 0
         self.algo_log_info = defaultdict(list)
 
-        self._ent_coeff = torch.tensor([ent_coeff]).to(agent.device)
-        self._log_ent_coeff = torch.log(self._ent_coeff).to(agent.device) # TODO: this was previously never used
         self.ent_coeff_optimizer = None
 
         if ent_coeff is None:
@@ -82,6 +80,9 @@ class SAC(Algorithm):
             self.ent_coeff_optimizer = torch.optim.Adam(
                 [self._log_ent_coeff], lr=ent_coeff_lr
             )  # TODO: how to handle the ent_coeff leraning rate?
+        else:
+            self._ent_coeff = torch.tensor([ent_coeff]).to(agent.device)
+            self._log_ent_coeff = torch.log(self._ent_coeff).to(agent.device) # TODO: this was previously never used
 
     def optimize_agent(
         self,

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -189,6 +189,14 @@ class SAC(Algorithm):
                 self.agent.model["q2"].parameters(),
                 self.clip_grad_norm,
             )
+            encoder_grad_norm = clip_grad_norm_(
+                self.agent.model["encoder"].parameters(), self.clip_grad_norm
+            )
+            tokenizer_grad_norm = clip_grad_norm_(
+                self.agent.model["tokenizer"].parameters(), self.clip_grad_norm
+            )
+            self.algo_log_info["encoder_grad_norm"].append(encoder_grad_norm.item())
+            self.algo_log_info["tokenizer_grad_norm"].append(tokenizer_grad_norm.item())
             self.algo_log_info["q1_grad_norm"].append(q1_grad_norm.item())
             self.algo_log_info["q2_grad_norm"].append(q2_grad_norm.item())
 

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -206,9 +206,8 @@ class SAC(Algorithm):
         min_q = torch.min(q1, q2)
         pi_losses = entropy_coeff * log_prob - min_q
         pi_loss = valid_mean(pi_losses)
-        self.algo_log_info["actor_loss"].append(pi_loss.item())
-        self.algo_log_info["min_q"].append(min_q.min().item())
-        self.algo_log_info["max_q"].append(min_q.max().item())
+        self.algo_log_info["q_min"].append(min_q.min().item())
+        self.algo_log_info["q_max"].append(min_q.max().item())
 
         # update Pi model parameters according to pi loss
         self.pi_optimizer.zero_grad()

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from itertools import chain
 from typing import Sequence
 
 import numpy as np
@@ -33,8 +34,7 @@ class SAC(Algorithm):
         replay_ratio: int,  # data_consumption / data_generation
         target_update_tau: float,  # tau=1 for hard update.
         target_update_interval: int,  # 1000 for hard update, 1 for soft.
-        ent_coeff: float
-        | None,  # if ent_coeff == None, it is learned # TODO: also allow setting initial value and target entropy
+        ent_coeff: float,
         ent_coeff_lr: float | None = None,
         clip_grad_norm: float | None = None,
         learning_rate_schedulers: Sequence[LRScheduler] | None = None,
@@ -68,9 +68,8 @@ class SAC(Algorithm):
 
         self.ent_coeff_optimizer = None
 
-        if ent_coeff is None:
-            assert ent_coeff_lr is not None
-            init_value = 1.0  # TODO: allow providing init value
+        if ent_coeff_lr is not None:
+            init_value = ent_coeff
             self.target_entropy = float(
                 -np.prod(self.agent.model["pi"].action_space.shape).astype(np.float32)  # type: ignore #TODO: model needs to save action_space?
             )
@@ -79,10 +78,10 @@ class SAC(Algorithm):
             ).requires_grad_(True)
             self.ent_coeff_optimizer = torch.optim.Adam(
                 [self._log_ent_coeff], lr=ent_coeff_lr
-            )  # TODO: how to handle the ent_coeff leraning rate?
+            )
         else:
             self._ent_coeff = torch.tensor([ent_coeff]).to(agent.device)
-            self._log_ent_coeff = torch.log(self._ent_coeff).to(agent.device) # TODO: this was previously never used
+            self._log_ent_coeff = torch.log(self._ent_coeff).to(agent.device)
 
     def optimize_agent(
         self,
@@ -144,30 +143,36 @@ class SAC(Algorithm):
         # using the gradients from the policy network.
         observation = self.agent.encode(samples["observation"])
 
-        new_action, log_prob = self.agent.pi(observation) # NOTE: reordering is necessary
-        log_prob = log_prob.reshape(-1, 1) #TODO: why?
+        new_action, log_prob = self.agent.pi(
+            observation.detach()
+        )  # NOTE: reordering is necessary
+        log_prob = log_prob.reshape(-1, 1)  # TODO: why?
 
         if self.ent_coeff_optimizer is not None:
-            ent_coeff = torch.exp(self._log_ent_coeff.detach())
-            ent_coeff_loss = -(self._log_ent_coeff * (log_prob + self.target_entropy).detach()).mean()
+            entropy_coeff = torch.exp(self._log_ent_coeff.detach())
+            ent_coeff_loss = -(
+                self._log_ent_coeff * (log_prob + self.target_entropy).detach()
+            ).mean()
             self.ent_coeff_optimizer.zero_grad()
             ent_coeff_loss.backward()
             self.ent_coeff_optimizer.step()
             self.algo_log_info["ent_ceff_loss"].append(ent_coeff_loss.item())
         else:
-            ent_coeff = self._ent_coeff
+            entropy_coeff = self._ent_coeff
 
         # compute target Q according to formula
         # r + gamma * (1 - d) * (min Q_targ(s', a') - alpha * log pi(s', a'))
         # where a' ~ pi(.|s')
         with torch.no_grad():
-            next_observation = self.agent.encode(samples["next_observation"])
+            next_observation = self.agent.target_encode(samples["next_observation"])
             next_action, next_log_prob = self.agent.pi(next_observation)
             target_q1, target_q2 = self.agent.target_q(next_observation, next_action)
-        min_target_q = torch.min(target_q1, target_q2)
-        next_q = min_target_q - ent_coeff * next_log_prob
-        y = samples["reward"] + self.discount * ~samples["terminated"] * next_q
-        q1, q2 = self.agent.q(observation.detach(), samples["action"])
+            min_target_q = torch.min(target_q1, target_q2)
+            entropy_bonus = -entropy_coeff * next_log_prob
+            y = samples["reward"] + self.discount * ~samples["terminated"] * (
+                min_target_q + entropy_bonus
+            )
+        q1, q2 = self.agent.q(observation, samples["action"])
         q_loss = 0.5 * valid_mean((y - q1) ** 2 + (y - q2) ** 2)
         self.algo_log_info["critic_loss"].append(q_loss.item())
 
@@ -188,6 +193,11 @@ class SAC(Algorithm):
             self.algo_log_info["q2_grad_norm"].append(q2_grad_norm.item())
 
         self.q_optimizer.step()
+        self.algo_log_info["critic_loss"].append(q_loss.item())
+        self.algo_log_info["ent_coeff"].append(entropy_coeff.item())
+        self.algo_log_info["mean_ent_bonus"].append(entropy_bonus.mean().item())
+        self.algo_log_info["max_target_q"].append(min_target_q.max().item())
+        self.algo_log_info["min_target_q"].append(min_target_q.min().item())
 
         # freeze Q models while optimizing policy model
         self.agent.freeze_q_models(True)
@@ -197,7 +207,7 @@ class SAC(Algorithm):
         # where a ~ pi(.|s)
         q1, q2 = self.agent.q(observation.detach(), new_action)
         min_q = torch.min(q1, q2)
-        pi_losses = ent_coeff * log_prob - min_q
+        pi_losses = entropy_coeff * log_prob - min_q
         pi_loss = valid_mean(pi_losses)
         self.algo_log_info["actor_loss"].append(pi_loss.item())
 

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -79,6 +79,9 @@ class SAC(Algorithm):
             self.ent_coeff_optimizer = torch.optim.Adam(
                 [self._log_ent_coeff], lr=ent_coeff_lr
             )
+            logger.info(
+                f"Using learnable entropy coefficient with target entropy of {self.target_entropy}"
+            )
         else:
             self._ent_coeff = torch.tensor([ent_coeff]).to(agent.device)
             self._log_ent_coeff = torch.log(self._ent_coeff).to(agent.device)

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from itertools import chain
 from typing import Sequence
 
 import numpy as np
 import torch
 from torch import Tensor
 from torch.nn.utils.clip_grad import clip_grad_norm_
-from torch.optim.lr_scheduler import _LRScheduler
+from torch.optim.lr_scheduler import LRScheduler
 
 import parllel.logger as logger
 from parllel import Array, ArrayDict
@@ -37,7 +36,7 @@ class SAC(Algorithm):
         ent_coeff: float,
         ent_coeff_lr: float | None = None,
         clip_grad_norm: float | None = None,
-        learning_rate_schedulers: Sequence[_LRScheduler] | None = None,
+        learning_rate_schedulers: Sequence[LRScheduler] | None = None,
         **kwargs,  # ignore additional arguments
     ):
         """Save input arguments."""
@@ -208,10 +207,6 @@ class SAC(Algorithm):
         min_q = torch.min(q1, q2)
         pi_losses = entropy_coeff * log_prob - min_q
         pi_loss = valid_mean(pi_losses)
-        self.algo_log_info["q_min"].append(min_q.min().item())
-        self.algo_log_info["q_max"].append(min_q.max().item())
-        self.algo_log_info["target_q_min"].append(min_target_q.min().item())
-        self.algo_log_info["target_q_max"].append(min_target_q.max().item())
 
         # update Pi model parameters according to pi loss
         self.pi_optimizer.zero_grad()

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -208,6 +208,8 @@ class SAC(Algorithm):
         pi_losses = entropy_coeff * log_prob - min_q
         pi_loss = valid_mean(pi_losses)
 
+        self.algo_log_info["actor_loss"].append(pi_loss.item())
+
         # update Pi model parameters according to pi loss
         self.pi_optimizer.zero_grad()
         pi_loss.backward()

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -172,6 +172,8 @@ class SAC(Algorithm):
         q1, q2 = self.agent.q(observation, samples["action"])
         q_loss = 0.5 * valid_mean((y - q1) ** 2 + (y - q2) ** 2)
         self.algo_log_info["critic_loss"].append(q_loss.item())
+        self.algo_log_info["mean_ent_bonus"].append(entropy_bonus.mean().item())
+        self.algo_log_info["ent_coeff"].append(entropy_coeff.item())
 
         # update Q model parameters according to Q loss
         self.q_optimizer.zero_grad()
@@ -208,6 +210,8 @@ class SAC(Algorithm):
         pi_loss = valid_mean(pi_losses)
         self.algo_log_info["q_min"].append(min_q.min().item())
         self.algo_log_info["q_max"].append(min_q.max().item())
+        self.algo_log_info["target_q_min"].append(min_target_q.min().item())
+        self.algo_log_info["target_q_max"].append(min_target_q.max().item())
 
         # update Pi model parameters according to pi loss
         self.pi_optimizer.zero_grad()

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Sequence
 
+import numpy as np
 import torch
 from torch import Tensor
 from torch.nn.utils.clip_grad import clip_grad_norm_
@@ -32,7 +33,9 @@ class SAC(Algorithm):
         replay_ratio: int,  # data_consumption / data_generation
         target_update_tau: float,  # tau=1 for hard update.
         target_update_interval: int,  # 1000 for hard update, 1 for soft.
-        ent_coeff: float,
+        ent_coeff: float
+        | None,  # if ent_coeff == None, it is learned # TODO: also allow setting initial value and target entropy
+        ent_coeff_lr: float | None = None,
         clip_grad_norm: float | None = None,
         learning_rate_schedulers: Sequence[LRScheduler] | None = None,
         **kwargs,  # ignore additional arguments
@@ -63,8 +66,22 @@ class SAC(Algorithm):
         self.update_counter = 0
         self.algo_log_info = defaultdict(list)
 
-        self._alpha = torch.tensor([ent_coeff]).to(agent.device)
-        self._log_alpha = torch.log(self._alpha).to(agent.device)
+        self._ent_coeff = torch.tensor([ent_coeff]).to(agent.device)
+        self._log_ent_coeff = torch.log(self._ent_coeff).to(agent.device) # TODO: this was previously never used
+        self.ent_coeff_optimizer = None
+
+        if ent_coeff is None:
+            assert ent_coeff_lr is not None
+            init_value = 1.0  # TODO: allow providing init value
+            self.target_entropy = float(
+                -np.prod(self.agent.model["pi"].action_space.shape).astype(np.float32)  # type: ignore #TODO: model needs to save action_space?
+            )
+            self._log_ent_coeff = torch.log(
+                torch.ones(1, device=agent.device) * init_value
+            ).requires_grad_(True)
+            self.ent_coeff_optimizer = torch.optim.Adam(
+                [self._log_ent_coeff], lr=ent_coeff_lr
+            )  # TODO: how to handle the ent_coeff leraning rate?
 
     def optimize_agent(
         self,
@@ -126,6 +143,19 @@ class SAC(Algorithm):
         # using the gradients from the policy network.
         observation = self.agent.encode(samples["observation"])
 
+        new_action, log_prob = self.agent.pi(observation) # NOTE: reordering is necessary
+        log_prob = log_prob.reshape(-1, 1) #TODO: why?
+
+        if self.ent_coeff_optimizer is not None:
+            ent_coeff = torch.exp(self._log_ent_coeff.detach())
+            ent_coeff_loss = -(self._log_ent_coeff * (log_prob + self.target_entropy).detach()).mean()
+            self.ent_coeff_optimizer.zero_grad()
+            ent_coeff_loss.backward()
+            self.ent_coeff_optimizer.step()
+            self.algo_log_info["ent_ceff_loss"].append(ent_coeff_loss.item())
+        else:
+            ent_coeff = self._ent_coeff
+
         # compute target Q according to formula
         # r + gamma * (1 - d) * (min Q_targ(s', a') - alpha * log pi(s', a'))
         # where a' ~ pi(.|s')
@@ -134,7 +164,7 @@ class SAC(Algorithm):
             next_action, next_log_prob = self.agent.pi(next_observation)
             target_q1, target_q2 = self.agent.target_q(next_observation, next_action)
         min_target_q = torch.min(target_q1, target_q2)
-        next_q = min_target_q - self._alpha * next_log_prob
+        next_q = min_target_q - ent_coeff * next_log_prob
         y = samples["reward"] + self.discount * ~samples["terminated"] * next_q
         q1, q2 = self.agent.q(observation.detach(), samples["action"])
         q_loss = 0.5 * valid_mean((y - q1) ** 2 + (y - q2) ** 2)
@@ -164,10 +194,9 @@ class SAC(Algorithm):
         # train policy model by maximizing the predicted Q value
         # maximize (min Q(s, a) - alpha * log pi(a, s))
         # where a ~ pi(.|s)
-        new_action, log_prob = self.agent.pi(observation)
         q1, q2 = self.agent.q(observation.detach(), new_action)
         min_q = torch.min(q1, q2)
-        pi_losses = self._alpha * log_prob - min_q
+        pi_losses = ent_coeff * log_prob - min_q
         pi_loss = valid_mean(pi_losses)
         self.algo_log_info["actor_loss"].append(pi_loss.item())
 

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -173,6 +173,8 @@ class SAC(Algorithm):
         self.algo_log_info["critic_loss"].append(q_loss.item())
         self.algo_log_info["mean_ent_bonus"].append(entropy_bonus.mean().item())
         self.algo_log_info["ent_coeff"].append(entropy_coeff.item())
+        self.algo_log_info["max_reward"].append(samples["reward"].max().item())
+        self.algo_log_info["min_reward"].append(samples["reward"].min().item())
 
         # update Q model parameters according to Q loss
         self.q_optimizer.zero_grad()
@@ -220,6 +222,8 @@ class SAC(Algorithm):
                 self.clip_grad_norm,
             )
             self.algo_log_info["pi_grad_norm"].append(pi_grad_norm.item())
+
+        self.algo_log_info["actor_loss"].append(pi_loss.item())
 
         self.pi_optimizer.step()
 

--- a/parllel/torch/algos/sac.py
+++ b/parllel/torch/algos/sac.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 from torch import Tensor
 from torch.nn.utils.clip_grad import clip_grad_norm_
-from torch.optim.lr_scheduler import LRScheduler
+from torch.optim.lr_scheduler import _LRScheduler
 
 import parllel.logger as logger
 from parllel import Array, ArrayDict
@@ -37,7 +37,7 @@ class SAC(Algorithm):
         ent_coeff: float,
         ent_coeff_lr: float | None = None,
         clip_grad_norm: float | None = None,
-        learning_rate_schedulers: Sequence[LRScheduler] | None = None,
+        learning_rate_schedulers: Sequence[_LRScheduler] | None = None,
         **kwargs,  # ignore additional arguments
     ):
         """Save input arguments."""


### PR DESCRIPTION
Add learnable entropy coefficient with settable initial value.
Target entropy set using action space passed to algo.
SacAgent creates and manages target encoder.
Update both SAC examples to use learnable entropy coefficient.